### PR TITLE
[backgammon] observeの実装

### DIFF
--- a/pgx/backgammon.py
+++ b/pgx/backgammon.py
@@ -88,7 +88,9 @@ def observe(state: BackgammonState, curr_player: jnp.ndarray) -> jnp.ndarray:
     return jax.lax.cond(
         curr_player == _curr_player,
         lambda: jnp.concatenate((turn * board, zero_one_dice_vec), axis=None),
-        lambda: jnp.concatenate((-turn * board, zero_one_dice_vec), axis=None),
+        lambda: jnp.concatenate(
+            (-turn * board, jnp.zeros(6, dtype=jnp.int8)), axis=None
+        ),
     )
 
 

--- a/tests/test_backgammon.py
+++ b/tests/test_backgammon.py
@@ -178,7 +178,7 @@ def test_observe():
         played_dice_num=jnp.int8(0),
     )
     expected_obs = jnp.concatenate(
-        (1 * board, jnp.array([0, 1, 0, 0, 0, 0])), axis=None
+        (1 * board, jnp.array([0, 0, 0, 0, 0, 0])), axis=None
     )
     assert (observe(state, jnp.int8(-1)) - expected_obs).sum() == 0
 


### PR DESCRIPTION
参照論文の特徴量
- ボード: 24
- bar 2
- off 2
の計28次元.

増やすべき情報
- サイコロの目: 6次元増やして play可能かどうかを0-1で表現?
- turn: current playerと紐づいているのでいらない気もします.

