### PR TITLE
関数の短縮とnp.putの代替関数の検証

### DIFF
--- a/pgx/shogi.py
+++ b/pgx/shogi.py
@@ -464,7 +464,7 @@ def _direction_to_hand(direction: int) -> int:
 
 
 def _piece_type(state: ShogiState, point: int) -> int:
-    return state.board[:, point].argmax()
+    return int(state.board[:, point].argmax())
 
 
 # dlshogiのactionの情報をShogiActionの情報に変換


### PR DESCRIPTION
jnpにはput関数が実装されていない
ｎ個飛ばしで数値を置き換える、みたいなのがjnpで実装できないかを検証してみる。
飛ばす必要がない（ある範囲をまとめて一定の数値に置き換える）場合はスライスとset関数でできた。効率を考えなければ、reshapeで形を変えてまとめて変更した後元に戻す、みたいなのはいけるかも
ついでに関数を短くして、説明が抜けている関数には説明を加えていく