### PR TITLE
Fix DDS cache check script

### DIFF
--- a/workspace/check-dds-cache.py
+++ b/workspace/check-dds-cache.py
@@ -1,5 +1,7 @@
+import sys
 import jax
 import jax.numpy as jnp
+import time
 
 
 @jax.vmap
@@ -45,15 +47,15 @@ def to_board(rng):
 
 
 HASH_SIZE = 2_500_000
-N = 1000
+N = int(sys.argv[1])
 
 rng = jax.random.PRNGKey(0)
 VALUES = jax.random.split(rng, HASH_SIZE)
 BOARDS = to_board(VALUES)
 KEYS = to_key(BOARDS)
-print(VALUES[:10])
-print(BOARDS[:10])
-print(KEYS[:10])
+# print(VALUES[:10])
+# print(BOARDS[:10])
+# print(KEYS[:10])
 
 
 @jax.vmap
@@ -62,5 +64,7 @@ def find_key(key):
     return VALUES[ix]
 
 
-print(find_key(KEYS[:3]))
-print(find_key(KEYS[10-3:10]))
+st = time.time()
+find_key(KEYS[:N])
+et = time.time()
+print(f"{et - st:.5f} sec")


### PR DESCRIPTION
#196 では `batch_size=3` のままだった。修正した実験結果は下記。
`batch_size=500` までは手元のmacbookで動いた。

```
(venv) [koyamada:~/github/pgx/workspace]$ python3 check-dds-cache.py 1                                                                                                                             (main✱)
0.08247 sec
(venv) [koyamada:~/github/pgx/workspace]$ python3 check-dds-cache.py 10                                                                                                                            (main✱)
0.17118 sec
(venv) [koyamada:~/github/pgx/workspace]$ python3 check-dds-cache.py 100                                                                                                                           (main✱)
8.27362 sec
(venv) [koyamada:~/github/pgx/workspace]$ python3 check-dds-cache.py 1000                                                                                                                          (main✱)
[1]    70824 killed     python3 check-dds-cache.py 1000
(venv) [koyamada:~/github/pgx/workspace]$ python3 check-dds-cache.py 500                                                                                                                           (main✱)
108.09875 sec
```