### PR TITLE
Improve DDS cache logic

### DIFF
--- a/workspace/check-dds-cache.py
+++ b/workspace/check-dds-cache.py
@@ -64,7 +64,23 @@ def find_key(key):
     return VALUES[ix]
 
 
+@jax.jit
+@jax.vmap
+def find_key2(key):
+    mask = jnp.where((KEYS == key).all(axis=1),
+                     jnp.ones(HASH_SIZE, dtype=jnp.bool_),
+                     jnp.zeros(HASH_SIZE, dtype=jnp.bool_))
+    ix = jnp.argmax(mask)
+    return VALUES[ix]
+
+
 st = time.time()
-find_key(KEYS[:N])
+find_key2(KEYS[:N])
 et = time.time()
 print(f"{et - st:.5f} sec")
+st = time.time()
+find_key2(KEYS[:N])
+et = time.time()
+print(f"{et - st:.5f} sec")
+results = find_key2(KEYS[:N])
+# print(results[:10])


### PR DESCRIPTION
works with `batch_size = 1000`

#196 #197

```
(venv) [koyamada:~/github/pgx/workspace]$ python3 check-dds-cache.py 1                                                                                                (sotetsuk/fix/dds-cache-improvement)
21.88422 sec
0.00314 sec
(venv) [koyamada:~/github/pgx/workspace]$ python3 check-dds-cache.py 10                                                                                               (sotetsuk/fix/dds-cache-improvement)
16.01710 sec
0.02834 sec
(venv) [koyamada:~/github/pgx/workspace]$ python3 check-dds-cache.py 100                                                                                              (sotetsuk/fix/dds-cache-improvement)
16.31263 sec
0.27696 sec
(venv) [koyamada:~/github/pgx/workspace]$ python3 check-dds-cache.py 1000                                                                                             (sotetsuk/fix/dds-cache-improvement)
18.82198 sec
2.76615 sec
```