### PR TITLE
[Go] Add number of jaxpr lines to benchmark

### DIFF
--- a/workspace/go_benchmark/benchmark.py
+++ b/workspace/go_benchmark/benchmark.py
@@ -32,7 +32,9 @@ def test(func):
         jax.jit(func, static_argnums=(1,))(state, 19)
         time_end = time.perf_counter()
         delta = (time_end - time_sta) * 1000
-        print(f"| `{func.__name__}` | {delta:.1f}ms |")
+        exp = jax.make_jaxpr(func, static_argnums=(1,))(state, 19)
+        n_line = len(str(exp).split('\n'))
+        print(f"| `{func.__name__}` | {n_line} | {delta:.1f}ms |")
         return
 
     try:
@@ -46,17 +48,23 @@ def test(func):
             jax.jit(func, static_argnums=(1,))(state, 0)
             time_end = time.perf_counter()
             delta = (time_end - time_sta) * 1000
+            exp = jax.make_jaxpr(func, static_argnums=(1,))(state, 0)
+            n_line = len(str(exp).split('\n'))
         except ZeroDivisionError:
             time_sta = time.perf_counter()
             jax.jit(func, static_argnums=(1,))(state, 19)
             time_end = time.perf_counter()
             delta = (time_end - time_sta) * 1000
+            exp = jax.make_jaxpr(func, static_argnums=(1,))(state, 19)
+            n_line = len(str(exp).split('\n'))
         except TypeError:
             time_sta = time.perf_counter()
             jax.jit(func, static_argnums=(2,))(state, 0, 19)
             time_end = time.perf_counter()
             delta = (time_end - time_sta) * 1000
-    print(f"| `{func.__name__}` | {delta:.1f}ms |")
+            exp = jax.make_jaxpr(func, static_argnums=(2,))(state, 0, 19)
+            n_line = len(str(exp).split('\n'))
+    print(f"| `{func.__name__}` | {n_line} | {delta:.1f}ms |")
 
 
 func_name = sys.argv[1]

--- a/workspace/go_benchmark/benchmark.sh
+++ b/workspace/go_benchmark/benchmark.sh
@@ -1,5 +1,5 @@
-echo "| function name | compile time |"
-echo "| :--- | ---: |"
+echo "| function name | # expr lines | compile time |"
+echo "| :--- | ---: | ---: |"
 for funcname in step _update_state_wo_legal_action _pass_move _not_pass_move _merge_ren _set_stone_next_to_oppo_ren _remove_stones legal_actions _get_reward _count_ji _get_alphazero_features
 do
     python3 benchmark.py $funcname


### PR DESCRIPTION
JITコンパイルの時間を計測するのは誤差があってよくわからなかったりするので、行数も測る


| function name | # expr lines | compile time |
| :--- | ---: | ---: |
| `step` | 9889 | 2042.4ms |
| `_update_state_wo_legal_action` | 4741 | 1295.5ms |
| `_pass_move` | 1619 | 408.7ms |
| `_not_pass_move` | 2804 | 761.9ms |
| `_merge_ren` | 570 | 172.7ms |
| `_set_stone_next_to_oppo_ren` | 843 | 221.0ms |
| `_remove_stones` | 410 | 114.3ms |
| `legal_actions` | 5053 | 717.6ms |
| `_get_reward` | 1302 | 353.6ms |
| `_count_ji` | 669 | 216.7ms |
| `_get_alphazero_features` | 233 | 62.3ms |
