### PR TITLE
[Go] Refactor `legal_actions`

### DIFF
--- a/pgx/go.py
+++ b/pgx/go.py
@@ -452,14 +452,10 @@ def _remove_stones(_state: GoState, _rm_ren_id, _rm_stone_xy) -> GoState:
 
 
 def legal_actions(state: GoState, size: int) -> jnp.ndarray:
-    return jnp.logical_not(
-        jax.lax.map(
-            lambda xy: _update_state_wo_legal_action(state, xy, size)[
-                0
-            ].terminated,
-            jnp.arange(0, size * size),
-        )
-    )
+    mask = state.ren_id_board == -1
+    mask = mask[0] & mask[1]
+    mask = jax.lax.cond(state.kou == -1, lambda: mask.at[state.kou].set(False), lambda: mask)
+    return mask
 
 
 def get_board(state: GoState) -> jnp.ndarray:


### PR DESCRIPTION
こういう実装もナイーブには思いつくが、問題がある？
`legal_actions` のコンパイル時間はほぼゼロになる

| function name | # expr lines | compile time |
| :--- | ---: | ---: |
| `step` | 3987 | 1206.4ms |
| `_update_state_wo_legal_action` | 3872 | 1160.8ms |
| `_pass_move` | 961 | 377.3ms |
| `_not_pass_move` | 2547 | 898.1ms |
| `_merge_ren` | 562 | 171.5ms |
| `_set_stone_next_to_oppo_ren` | 837 | 198.2ms |
| `_remove_stones` | 401 | 99.9ms |
| `legal_actions` | 31 | 15.9ms |
| `_get_reward` | 730 | 316.4ms |
| `_count_ji` | 383 | 181.0ms |
| `_get_alphazero_features` | 233 | 63.5ms |
