### PR TITLE
[AnimalShogi] Refactor `_filter_leave_check_actions`

### DIFF
--- a/pgx/_animal_shogi.py
+++ b/pgx/_animal_shogi.py
@@ -668,7 +668,6 @@ def _filter_leave_check_actions(
     new_array = copy.deepcopy(array)
     moves = _king_move(king_sq).reshape(12)
     for i in range(12):
-        # 王手をかけている駒の位置以外への移動は王手放置
         for j in range(15):
             # 駒打ちのフラグは全て折る
             if j > 8:
@@ -676,7 +675,10 @@ def _filter_leave_check_actions(
             # 王手をかけている駒の場所以外への移動ははじく
             if check_piece[i] == 0:
                 new_array[12 * j + i] = 0
-        # 玉の移動はそれ以外でも可能だがフラグが折れてしまっているので立て直す
+
+    # 玉の移動はそれ以外でも可能だがフラグが折れてしまっているので立て直す
+    for i in range(12):
+        # 王手をかけている駒の位置以外への移動は王手放置
         if moves[i] == 0:
             continue
         direction = _point_to_direction(king_sq, i, False, turn)


### PR DESCRIPTION
Numpy実装でこのforを２つ分ける変更をするとテストは通るが、
Jax実装で同等の変更をするとNumpy, Jaxの互換性テストが落ちる。
なので意味が違うということっぽいが、違いがわからない。
此の実装でもあっていそうな気がするが。。。。。。

ようするに、前半のforは `(15, 12)` 行列に直したときに、行 or 列の変更しかしていない（と思っている）ので、
分離できると嬉しい

この変更ができると、Jax実装で効率化しやすい

@youyou-ku もともとのNumpy実装、なんでforの内側に入ってるのかわかりますか？