### PR TITLE
[Go] Remove `available_ren_id`

### DIFF
--- a/pgx/go.py
+++ b/pgx/go.py
@@ -24,7 +24,7 @@ class GoState:
     # 横幅, マスの数ではない
     size: jnp.ndarray = jnp.int32(19)  # type:ignore
 
-    # 連
+    # 連の代表点（一番小さいマス目）のマス目の座標
     ren_id_board: jnp.ndarray = jnp.full(
         (2, 19 * 19), -1, dtype=jnp.int32
     )  # type:ignore


### PR DESCRIPTION
石の座標をそのまま連のIDとして使えばいいので、IDを管理する必要はない

#35 から次のように変わっている

![190896524-d23be220-2c6d-4a4a-b13a-f7bd6c29bdf3](https://user-images.githubusercontent.com/5868442/216527482-b8342ac9-4b87-4f53-a1d9-5839774c921b.png)
