### PR TITLE
Remove `adj_ren_id`

### DIFF
--- a/pgx/go.py
+++ b/pgx/go.py
@@ -306,8 +306,6 @@ def _merge_ren(_state: GoState, _xy: int, _adj_xy: int):
     new_id = ren_id_board.at[_xy].get()
     adj_ren_id = ren_id_board.at[_adj_xy].get()
 
-    is_same_color = (new_id >= 0) & (adj_ren_id >= 0)
-
     # 大きいidの連を消し、小さいidの連と繋げる
     large_id = jnp.maximum(new_id, adj_ren_id)
     small_id = jnp.minimum(new_id, adj_ren_id)


### PR DESCRIPTION
`adj_ren_id` はもう使われてない気がするので、消しました。テストは通ってますが、もともとなんのために使われていたのか良くわかってないので、一応は確認したい。

## Before

| function name | # expr lines | compile time |
| :--- | ---: | ---: |
| `step` | 9079 | 2548.5ms |
| `_update_state_wo_legal_action` | 4437 | 1456.2ms |
| `_pass_move` | 1891 | 558.0ms |
| `_not_pass_move` | 2197 | 645.6ms |
| `_merge_ren` | 482 | 172.2ms |
| `_set_stone_next_to_oppo_ren` | 676 | 189.3ms |
| `_remove_stones` | 297 | 92.2ms |
| `legal_actions` | 4530 | 1009.4ms |
| `_get_reward` | 1492 | 476.1ms |
| `_count_ji` | 744 | 272.3ms |
| `_get_alphazero_features` | 215 | 60.1ms |

## After

| function name | # expr lines | compile time |
| :--- | ---: | ---: |
| `step` | 7925 | 1888.6ms |
| `_update_state_wo_legal_action` | 3855 | 1134.4ms |
| `_pass_move` | 1890 | 532.4ms |
| `_not_pass_move` | 1622 | 444.8ms |
| `_merge_ren` | 259 | 81.7ms |
| `_set_stone_next_to_oppo_ren` | 462 | 143.7ms |
| `_remove_stones` | 230 | 76.2ms |
| `legal_actions` | 3956 | 759.5ms |
| `_get_reward` | 1492 | 479.2ms |
| `_count_ji` | 744 | 269.6ms |
| `_get_alphazero_features` | 215 | 61.8ms |
