### PR TITLE
[Backgammon] Avoid same computation

### DIFF
--- a/pgx/backgammon.py
+++ b/pgx/backgammon.py
@@ -130,11 +130,12 @@ def _no_winning_step(
     """
     勝利者がいない場合のstep, ターン終了の条件を満たせばターンを変更する.
     """
+    s = _change_turn(state)
     return jax.lax.cond(
         _is_turn_end(state),
         lambda: (
-            _change_turn(state).curr_player,
-            _change_turn(state),
+            s.curr_player,
+            s,
             0,
         ),
         lambda: (state.curr_player, state, 0),


### PR DESCRIPTION
## before

| function name | # jaxpr lines | compile time |
| :--- | ---: | ---: |
| `init` | 1079 | 473.1ms |
| `step` | 6492 | 1664.6ms |
| `_normal_step` | 3822 | 1004.3ms |
| `_winning_step` | 86 | 32.3ms |
| `_no_winning_step` | 2338 | 551.3ms |
| `observe` | 91 | 31.9ms |
| `_change_turn` | 970 | 425.1ms |
| `_legal_action_mask` | 852 | 299.2ms |
| `_is_action_legal` | 706 | 169.7ms |
| `_legal_action_mask_for_valid_single_dice` | 775 | 239.6ms |
| `_calc_win_score` | 85 | 28.7ms |
| `_is_all_on_home_board` | 58 | 19.7ms |
| `_rear_distance` | 204 | 81.6ms |
| `_update_by_action` | 1190 | 384.3ms |
| `_move` | 202 | 53.9ms |

## after 

| function name | # jaxpr lines | compile time |
| :--- | ---: | ---: |
| `init` | 800 | 411.1ms |
| `step` | 3952 | 1286.7ms |
| `_normal_step` | 1897 | 748.2ms |
| `_winning_step` | 64 | 28.8ms |
| `_no_winning_step` | 727 | 386.1ms |
| `observe` | 91 | 30.7ms |
| `_change_turn` | 703 | 358.6ms |
| `_legal_action_mask` | 585 | 233.1ms |
| `_is_action_legal` | 472 | 144.5ms |
| `_legal_action_mask_for_valid_single_dice` | 523 | 192.7ms |
| `_calc_win_score` | 63 | 25.5ms |
| `_is_all_on_home_board` | 58 | 19.9ms |
| `_rear_distance` | 204 | 81.8ms |
| `_update_by_action` | 896 | 318.1ms |
| `_move` | 202 | 53.3ms |