### PR TITLE
[Backgammon] Fix infinite loop

### DIFF
--- a/pgx/backgammon.py
+++ b/pgx/backgammon.py
@@ -267,8 +267,9 @@ def _is_turn_end(state: State) -> bool:
     """
     play可能なサイコロ数が0の場合ないしlegal_actionがない場合交代
     """
-    return (state.playable_dice.sum() == -4) | (
-        state.legal_action_mask.sum() == 0
+    return ~state.terminated & (
+        (state.playable_dice.sum() == -4)
+        | (state.legal_action_mask.sum() == 0)
     )  # type: ignore
 
 


### PR DESCRIPTION
`terminated` のときに `cond` で条件分岐しても `fori_loop` に突入することが原因なら、これがとりあえずhotfixとしてはありかなと思います @nissymori 