### PR TITLE
Avoid calling step if illegal action is taken

### DIFF
--- a/pgx/core.py
+++ b/pgx/core.py
@@ -48,7 +48,7 @@ class Env(abc.ABC):
         # If the state is already terminated, environment does not take usual step, but
         # return the same state with zero-rewards for all players
         state = jax.lax.cond(
-            state.terminated,
+            state.terminated | is_illegal,
             lambda: self._step_if_terminated(state),
             lambda: self._step(state, action),
         )


### PR DESCRIPTION
#403 #410 #411

ちなみにこれはillegal actionが取られたときに通常のstepの呼び出しを避けてますが、無限ループは直らないですね。

@nissymori 