### PR TITLE
[Backgammon]Add no op

### DIFF
--- a/pgx/backgammon.py
+++ b/pgx/backgammon.py
@@ -53,7 +53,7 @@ class State(core.State):
     observation: jnp.ndarray = jnp.zeros(34, dtype=jnp.int8)
     reward: jnp.ndarray = jnp.float32([0.0, 0.0])
     terminated: jnp.ndarray = FALSE
-    # micro action = 6 * src + die
+    # micro action = 6 * src + die src(no-op, bar, board)
     legal_action_mask: jnp.ndarray = jnp.zeros(6 * 26 + 6, dtype=jnp.bool_)
     # --- Backgammon specific ---
     # 各point(24) bar(2) off(2)にあるcheckerの数 負の値は白, 正の値は黒


### PR DESCRIPTION
#410 
パスはsimulator側ではなく, agentが選ぶようにする.

変更点
legal_action
- 現状: 全diceについてとれるactionが何もなければ全部False
- 変更: 全diceについてとれるactionが何もなければ"no-op"のところのみにbitを立てる.
change_turn
- 現状: 状態のupdateが終わった後に(legal_actionがない or play可能なサイコロがない)場合交代
- 変更 1. `no_op`を受け取った時点で状態のupdateを待たずに交代 2. 状態のupdate後にplay可能なサイコロがなければ交代


- [ ] test変更
- [ ] 実装