### PR TITLE
[Visualizer, Bridge] make visualizer flexible

### DIFF
--- a/pgx/dwg/bridge_bidding.py
+++ b/pgx/dwg/bridge_bidding.py
@@ -150,6 +150,7 @@ def _make_bridge_dwg(dwg, state: BridgeBiddingState, config):
                 stroke_width="2px",
             )
         )
+
         # v line
         board_g.add(
             dwg.line(
@@ -171,6 +172,7 @@ def _make_bridge_dwg(dwg, state: BridgeBiddingState, config):
                 font_weight="bold",
             )
         )
+
         # val
         if (state.vul_NS and i % 2 == 0) or (state.vul_EW and i % 2 == 1):
             board_g.add(

--- a/pgx/dwg/connect_four.py
+++ b/pgx/dwg/connect_four.py
@@ -2,7 +2,6 @@ from pgx.connect_four import State as ConnectFourState
 
 
 def _make_connect_four_dwg(dwg, state: ConnectFourState, config):
-
     GRID_SIZE = config["GRID_SIZE"]
     BOARD_WIDTH = config["BOARD_WIDTH"]
     BOARD_HEIGHT = config["BOARD_HEIGHT"]

--- a/pgx/dwg/go.py
+++ b/pgx/dwg/go.py
@@ -3,7 +3,6 @@ from pgx.go import get_board
 
 
 def _make_go_dwg(dwg, state: GoState, config):
-
     GRID_SIZE = config["GRID_SIZE"]
     BOARD_SIZE = config["BOARD_WIDTH"]
     color_set = config["COLOR_SET"]

--- a/pgx/dwg/othello.py
+++ b/pgx/dwg/othello.py
@@ -2,7 +2,6 @@ from pgx.othello import State as OthelloState
 
 
 def _make_othello_dwg(dwg, state: OthelloState, config):
-
     GRID_SIZE = config["GRID_SIZE"]
     BOARD_SIZE = config["BOARD_WIDTH"]
     color_set = config["COLOR_SET"]

--- a/pgx/dwg/sparrowmahjong.py
+++ b/pgx/dwg/sparrowmahjong.py
@@ -7,7 +7,6 @@ from pgx.suzume_jong import _tile_type_to_str
 
 
 def _make_sparrowmahjong_dwg(dwg, state: SparrowMahjongState, config):
-
     GRID_SIZE = config["GRID_SIZE"]
     BOARD_WIDTH = config["BOARD_WIDTH"]
     BOARD_HEIGHT = config["BOARD_HEIGHT"]

--- a/pgx/visualizer.py
+++ b/pgx/visualizer.py
@@ -103,8 +103,8 @@ class Visualizer:
         states,
     ):
         import ipywidgets as widgets  # type:ignore
-        from IPython.display import display
         from IPython.core.display import display_svg
+        from IPython.display import display
 
         svg_strings = [
             self._to_dwg_from_states(


### PR DESCRIPTION
カードが1行に収まらない場合は枠を拡張するように変更
- north, southは右に伸ばす
- east, westは下に伸ばす

![output](https://user-images.githubusercontent.com/72956592/222959895-7ed3be92-3419-48c8-90b7-733efb428eef.svg)
