### PR TITLE
[2048, Visualizer] Support when exceeding 2048

### DIFF
--- a/pgx/_dwg/play2048.py
+++ b/pgx/_dwg/play2048.py
@@ -20,6 +20,9 @@ def _make_2048_dwg(dwg, state: Play2048State, config):
     board_g = dwg.g()
     for i, _exp2 in enumerate(state.board):
         exp2 = int(_exp2)
+        num = 2**exp2
+        if exp2 > 11:
+            exp2 = 11
         x = (i % 4) * GRID_SIZE
         y = (i // 4) * GRID_SIZE
         _color = (
@@ -44,7 +47,7 @@ def _make_2048_dwg(dwg, state: Play2048State, config):
 
         if exp2 == 0:
             continue
-        num = 2**exp2
+
         font_size = 18
         large_num_color = (
             f"#{(145+exp2*10):02x}{(145+exp2*10):02x}{(145+exp2*10):02x}"


### PR DESCRIPTION
数値をグレースケールに変換していたので、2048より大きくなると#FFFFFFを超えたりしてバグる
2048より大きいときは2048として扱うことで修正
（16384より大きくなると枠からはみ出すが、これはどうしようもない気が…。）

![スクリーンショット 2023-03-22 175229](https://user-images.githubusercontent.com/72956592/226850544-2c7d415a-a3c9-4a05-a23b-76afbdcd5dc8.png)
