### PR TITLE
[BridgeBidding] Fix part of state passed in `pgx._make_bridge_dwg` is not updated

### DIFF
--- a/pgx/_visualizer.py
+++ b/pgx/_visualizer.py
@@ -623,6 +623,7 @@ class Visualizer:
         elif isinstance(_states, BridgeBiddingState):
             return BridgeBiddingState(  # type:ignore
                 turn=_states.turn[_i],
+                dealer=_states.dealer[_i],
                 current_player=_states.current_player[_i],
                 hand=_states.hand[_i],
                 bidding_history=_states.bidding_history[_i],


### PR DESCRIPTION
#728 
`pgx._visualizer`において、`states.dealer`を入れるようにした。
dealerがNに固定されてしまうバグを修正。