### PR TITLE
[BridgeBidding] Add illegal action penalty

### DIFF
--- a/pgx/bridge_bidding.py
+++ b/pgx/bridge_bidding.py
@@ -122,6 +122,10 @@ class BridgeBidding(core.Env):
     def num_players(self) -> int:
         return 4
 
+    @property
+    def _illegal_action_penalty(self) -> float:
+        return -7600.0
+
 
 @jax.jit
 def init(rng: jax.random.KeyArray) -> State:

--- a/tests/test_bridge_bidding.py
+++ b/tests/test_bridge_bidding.py
@@ -77,6 +77,14 @@ def test_duplicate():
         )
 
 
+def test_illegal_action_penalty():
+    key = jax.random.PRNGKey(0)
+    state = init(key)
+    state = step(state, 36)
+    print(state.reward)
+    assert jnp.all(state.reward == jnp.array([22800, -7600, 22800, 22800]))
+
+
 def test_step():
     #  player_id: 0 = N, 1 = S, 2 = W, 3 = E
     #   0  3  1  2


### PR DESCRIPTION
#714 
`BridgeBidding(core.Env)`にillegal_actionに対するpenaltyとして-7600(ブリッジの最低score)を与えるようにした。