### PR TITLE
[BridgeBidding] Change the executing order of `vmap` and `duplicate`

### DIFF
--- a/workspace/bridge_bidding-duplicate.py
+++ b/workspace/bridge_bidding-duplicate.py
@@ -98,31 +98,10 @@ def _duplicate_step(
     )
 
 
-"""
-    if not state.terminated:
-        state = state  # no changes
-    else:
-        if has_duplicate_result:
-            reward = _imp_reward(table_a_reward, state.reward)
-            # terminates!
-            # fmt: off
-            state = state.replace(reward=reward)   # type: ignore
-            # fmt: on
-            print(f"calc imp: {reward}")
-            has_duplicate_result = False
-        else:
-            table_a_reward = state.reward
-            state = duplicate_init(
-                state
-            )  # reward = zeros as results are not determined yet
-            has_duplicate_result = True
-    return (state, table_a_reward, has_duplicate_result)
-"""
-
 env_id: pgx.EnvId = "bridge_bidding"
 env = pgx.make(env_id)
 # run api test
-# pgx.api_test(env, 100)
+pgx.api_test(env, 100)
 
 # jit
 init = jax.jit(jax.vmap(env.init))

--- a/workspace/bridge_bidding-duplicate.py
+++ b/workspace/bridge_bidding-duplicate.py
@@ -67,14 +67,20 @@ def duplicate_init(
 ) -> State:
     """Make duplicated state where NSplayer and EWplayer are swapped"""
     ix = jnp.array([1, 0, 3, 2])
+    shuffled_players = state.shuffled_players[ix]
+    current_player = shuffled_players[state.dealer]
+    legal_actions = jnp.ones(38, dtype=jnp.bool_)
+    # 最初はdable, redoubleできない
+    legal_actions = legal_actions.at[36].set(False)
+    legal_actions = legal_actions.at[37].set(False)
     duplicated_state = State(  # type: ignore
         shuffled_players=state.shuffled_players[ix],
-        current_player=state.current_player,
+        current_player=current_player,
         hand=state.hand,
         dealer=state.dealer,
         vul_NS=state.vul_NS,
         vul_EW=state.vul_EW,
-        legal_action_mask=state.legal_action_mask,
+        legal_action_mask=legal_actions,
     )
     return duplicated_state
 


### PR DESCRIPTION
`vmap`と`duplicate`の実行順序を変更し、ロスを無くした自然なduplicate対戦を実装する
#714 