### PR TITLE
[Experimental] add `state._info` to `State`

### DIFF
--- a/pgx/_test.py
+++ b/pgx/_test.py
@@ -121,7 +121,7 @@ def _validate_taking_action_after_terminal(state: State, step_fn):
     state = step_fn(state, action)
     assert (state.reward == 0).all()
     for field in fields(state):
-        if field.name in ["reward", "steps"]:
+        if field.name in ["reward", "steps", "_info"]:
             continue
         assert (
             getattr(state, field.name) == getattr(prev_state, field.name)

--- a/pgx/core.py
+++ b/pgx/core.py
@@ -13,12 +13,12 @@
 # limitations under the License.
 
 import abc
-from typing import Literal, Optional, Tuple, get_args
+from typing import Literal, Optional, Tuple, get_args, Any, Dict
 
 import jax
 import jax.numpy as jnp
 
-from pgx._flax.struct import dataclass
+from pgx._flax.struct import dataclass, field
 
 TRUE = jnp.bool_(True)
 FALSE = jnp.bool_(False)
@@ -71,6 +71,7 @@ class State(abc.ABC):
     #   - supposed NOT to be used by agent
     _rng_key: jax.random.KeyArray
     _step_count: jnp.ndarray
+    _info: Dict[str, Any] = field(default_factory=dict)  # experimental
 
     @property
     @abc.abstractmethod


### PR DESCRIPTION
Example usage:


```
import jax
import jax.numpy as jnp
import pgx
from pgx.experimental.utils import act_randomly


env = pgx.make("tic_tac_toe")
act_randomly = jax.jit(act_randomly)


@jax.jit
@jax.vmap
def init_fn(key):
    state = env.init(key)
    state = state.replace(_info={'count': jnp.int32(0)})
    return state


@jax.jit
@jax.vmap
def step_fn(state, action):
    state = env.step(state, action)
    _info = state._info
    _info['count'] += jnp.int32(1)
    state = state.replace(_info=_info)
    return state


key = jax.random.PRNGKey(0)
key, subkey = jax.random.split(key)
keys = jax.random.split(subkey, 3)


state = init_fn(keys)
while not state.terminated.all():
    key, subkey = jax.random.split(key)
    action = act_randomly(subkey, state)
    state = step_fn(state, action)
    print(state._info)
```