### PR TITLE
Revert "[API] Use chex's dataclass instead of flax's dataclass"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ check:
 	black pgx --check --diff --exclude=pgx/_flax
 	blackdoc pgx --check --exclude=pgx/_flax
 	flake8 --config pyproject.toml --ignore E203,E501,W503,E741 pgx --exclude=pgx/_flax
-	mypy --config pyproject.toml pgx --exclude=pgx/_flax/* --ignore-missing-imports
+	mypy --config pyproject.toml pgx --exclude=pgx/_flax/* 
 	isort pgx --check --diff --skip-glob=pgx/_flax
 
 install:

--- a/pgx/_flax/struct.py
+++ b/pgx/_flax/struct.py
@@ -1,0 +1,225 @@
+# Copyright 2023 The Flax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Utilities for defining custom classes that can be used with jax transformations.
+"""
+
+import dataclasses
+from typing import TypeVar, Callable, Tuple, Union, Any
+
+from . import serialization
+
+import jax
+from typing_extensions import dataclass_transform  # pytype: disable=not-supported-yet
+
+
+_T = TypeVar("_T")
+
+
+def field(pytree_node=True, **kwargs):
+  return dataclasses.field(metadata={'pytree_node': pytree_node}, **kwargs)
+
+
+@dataclass_transform(field_descriptors=(field,)) # type: ignore[literal-required]
+def dataclass(clz: _T) -> _T:
+  """Create a class which can be passed to functional transformations.
+
+  NOTE: Inherit from ``PyTreeNode`` instead to avoid type checking issues when
+  using PyType.
+
+  Jax transformations such as `jax.jit` and `jax.grad` require objects that are
+  immutable and can be mapped over using the `jax.tree_util` methods.
+  The `dataclass` decorator makes it easy to define custom classes that can be
+  passed safely to Jax. For example::
+
+    from flax import struct
+
+    @struct.dataclass
+    class Model:
+      params: Any
+      # use pytree_node=False to indicate an attribute should not be touched
+      # by Jax transformations.
+      apply_fn: FunctionType = struct.field(pytree_node=False)
+
+      def __apply__(self, *args):
+        return self.apply_fn(*args)
+
+    model = Model(params, apply_fn)
+
+    model.params = params_b  # Model is immutable. This will raise an error.
+    model_b = model.replace(params=params_b)  # Use the replace method instead.
+
+    # This class can now be used safely in Jax to compute gradients w.r.t. the
+    # parameters.
+    model = Model(params, apply_fn)
+    model_grad = jax.grad(some_loss_fn)(model)
+
+  Note that dataclasses have an auto-generated ``__init__`` where
+  the arguments of the constructor and the attributes of the created
+  instance match 1:1. This correspondence is what makes these objects
+  valid containers that work with JAX transformations and
+  more generally the `jax.tree_util` library.
+
+  Sometimes a "smart constructor" is desired, for example because
+  some of the attributes can be (optionally) derived from others.
+  The way to do this with Flax dataclasses is to make a static or
+  class method that provides the smart constructor.
+  This way the simple constructor used by `jax.tree_util` is
+  preserved. Consider the following example::
+
+    @struct.dataclass
+    class DirectionAndScaleKernel:
+      direction: Array
+      scale: Array
+
+      @classmethod
+      def create(cls, kernel):
+        scale = jax.numpy.linalg.norm(kernel, axis=0, keepdims=True)
+        directin = direction / scale
+        return cls(direction, scale)
+
+  Args:
+    clz: the class that will be transformed by the decorator.
+  Returns:
+    The new class.
+  """
+  # check if already a flax dataclass
+  if '_flax_dataclass' in clz.__dict__:
+    return clz
+
+  data_clz = dataclasses.dataclass(frozen=True)(clz) # type: ignore
+  meta_fields = []
+  data_fields = []
+  for field_info in dataclasses.fields(data_clz):
+    is_pytree_node = field_info.metadata.get('pytree_node', True)
+    if is_pytree_node:
+      data_fields.append(field_info.name)
+    else:
+      meta_fields.append(field_info.name)
+
+  def replace(self, **updates):
+    """"Returns a new object replacing the specified fields with new values."""
+    return dataclasses.replace(self, **updates)
+
+  data_clz.replace = replace
+
+  def iterate_clz(x):
+    meta = tuple(getattr(x, name) for name in meta_fields)
+    data = tuple(getattr(x, name) for name in data_fields)
+    return data, meta
+
+  def iterate_clz_with_keys(x):
+    meta = tuple(getattr(x, name) for name in meta_fields)
+    data = tuple(
+        (jax.tree_util.GetAttrKey(name), getattr(x, name))
+        for name in data_fields
+    )
+    return data, meta
+
+  def clz_from_iterable(meta, data):
+    meta_args = tuple(zip(meta_fields, meta))
+    data_args = tuple(zip(data_fields, data))
+    kwargs = dict(meta_args + data_args)
+    return data_clz(**kwargs)
+
+  if hasattr(jax.tree_util, 'register_pytree_with_keys'):
+    jax.tree_util.register_pytree_with_keys(
+        data_clz, iterate_clz_with_keys, clz_from_iterable
+    )
+  else:
+    jax.tree_util.register_pytree_node(data_clz, iterate_clz, clz_from_iterable)
+    def keypaths(_):
+      return [
+          jax.tree_util.AttributeKeyPathEntry(name) for name in data_fields
+      ]
+    jax.tree_util.register_keypaths(data_clz, keypaths)
+
+  def to_state_dict(x):
+    state_dict = {name: serialization.to_state_dict(getattr(x, name))
+                  for name in data_fields}
+    return state_dict
+
+  def from_state_dict(x, state):
+    """Restore the state of a data class."""
+    state = state.copy()  # copy the state so we can pop the restored fields.
+    updates = {}
+    for name in data_fields:
+      if name not in state:
+        raise ValueError(f'Missing field {name} in state dict while restoring'
+                         f' an instance of {clz.__name__},'
+                         f' at path {serialization.current_path()}')
+      value = getattr(x, name)
+      value_state = state.pop(name)
+      updates[name] = serialization.from_state_dict(value, value_state, name=name)
+    if state:
+      names = ','.join(state.keys())
+      raise ValueError(f'Unknown field(s) "{names}" in state dict while'
+                       f' restoring an instance of {clz.__name__}'
+                       f' at path {serialization.current_path()}')
+    return x.replace(**updates)
+
+  serialization.register_serialization_state(
+      data_clz, to_state_dict, from_state_dict)
+
+  # add a _flax_dataclass flag to distinguish from regular dataclasses
+  data_clz._flax_dataclass = True # type: ignore[attr-defined]
+
+  return data_clz # type: ignore
+
+
+TNode = TypeVar('TNode', bound='PyTreeNode')
+
+
+@dataclass_transform(field_descriptors=(field,)) # type: ignore[literal-required]
+class PyTreeNode:
+  """Base class for dataclasses that should act like a JAX pytree node.
+
+  See ``flax.struct.dataclass`` for the ``jax.tree_util`` behavior.
+  This base class additionally avoids type checking errors when using PyType.
+
+  Example::
+
+    from flax import struct
+
+    class Model(struct.PyTreeNode):
+      params: Any
+      # use pytree_node=False to indicate an attribute should not be touched
+      # by Jax transformations.
+      apply_fn: FunctionType = struct.field(pytree_node=False)
+
+      def __apply__(self, *args):
+        return self.apply_fn(*args)
+
+    model = Model(params, apply_fn)
+
+    model.params = params_b  # Model is immutable. This will raise an error.
+    model_b = model.replace(params=params_b)  # Use the replace method instead.
+
+    # This class can now be used safely in Jax to compute gradients w.r.t. the
+    # parameters.
+    model = Model(params, apply_fn)
+    model_grad = jax.grad(some_loss_fn)(model)
+
+  """
+
+  def __init_subclass__(cls):
+    dataclass(cls)  # pytype: disable=wrong-arg-types
+
+  def __init__(self, *args, **kwargs):
+    # stub for pytype
+    raise NotImplementedError
+
+  def replace(self: TNode, **overrides) -> TNode:
+    # stub for pytype
+    raise NotImplementedError

--- a/pgx/_mahjong/_action.py
+++ b/pgx/_mahjong/_action.py
@@ -1,4 +1,4 @@
-from chex import dataclass
+from pgx._flax.struct import dataclass
 
 
 @dataclass

--- a/pgx/animal_shogi.py
+++ b/pgx/animal_shogi.py
@@ -15,9 +15,9 @@ from functools import partial
 
 import jax
 import jax.numpy as jnp
-from chex import dataclass
 
 import pgx.core as core
+from pgx._flax.struct import dataclass
 
 TRUE = jnp.bool_(True)
 FALSE = jnp.bool_(False)

--- a/pgx/backgammon.py
+++ b/pgx/backgammon.py
@@ -16,9 +16,9 @@ from functools import partial
 
 import jax
 import jax.numpy as jnp
-from chex import dataclass
 
 import pgx.core as core
+from pgx._flax.struct import dataclass
 
 TRUE = jnp.bool_(True)
 FALSE = jnp.bool_(False)

--- a/pgx/bridge_bidding.py
+++ b/pgx/bridge_bidding.py
@@ -18,9 +18,9 @@ from typing import Tuple
 import jax
 import jax.numpy as jnp
 import numpy as np
-from chex import dataclass
 
 import pgx.core as core
+from pgx._flax.struct import dataclass
 
 TRUE = jnp.bool_(True)
 FALSE = jnp.bool_(False)

--- a/pgx/chess.py
+++ b/pgx/chess.py
@@ -14,7 +14,6 @@
 
 import jax
 import jax.numpy as jnp
-from chex import dataclass
 
 import pgx.core as core
 from pgx._chess_utils import (  # type: ignore
@@ -27,6 +26,7 @@ from pgx._chess_utils import (  # type: ignore
     PLANE_MAP,
     TO_MAP,
 )
+from pgx._flax.struct import dataclass
 
 TRUE = jnp.bool_(True)
 FALSE = jnp.bool_(False)

--- a/pgx/connect_four.py
+++ b/pgx/connect_four.py
@@ -14,9 +14,9 @@
 
 import jax
 import jax.numpy as jnp
-from chex import dataclass
 
 import pgx.core as core
+from pgx._flax.struct import dataclass
 
 FALSE = jnp.bool_(False)
 TRUE = jnp.bool_(True)

--- a/pgx/core.py
+++ b/pgx/core.py
@@ -17,7 +17,8 @@ from typing import Literal, Optional, Tuple, get_args
 
 import jax
 import jax.numpy as jnp
-from chex import dataclass
+
+from pgx._flax.struct import dataclass
 
 TRUE = jnp.bool_(True)
 FALSE = jnp.bool_(False)
@@ -67,6 +68,7 @@ class State(abc.ABC):
 
         state = env.step(state, action)
 
+    Serialization via `flax.struct.serialization` is supported.
     There are 6 common attributes over all games:
 
     Attributes:

--- a/pgx/go.py
+++ b/pgx/go.py
@@ -15,10 +15,10 @@
 from functools import partial
 
 import jax
-from chex import dataclass
 from jax import numpy as jnp
 
 import pgx.core as core
+from pgx._flax.struct import dataclass
 
 FALSE = jnp.bool_(False)
 TRUE = jnp.bool_(True)

--- a/pgx/hex.py
+++ b/pgx/hex.py
@@ -16,9 +16,9 @@ from functools import partial
 
 import jax
 import jax.numpy as jnp
-from chex import dataclass
 
 import pgx.core as core
+from pgx._flax.struct import dataclass
 
 FALSE = jnp.bool_(False)
 TRUE = jnp.bool_(True)

--- a/pgx/kuhn_poker.py
+++ b/pgx/kuhn_poker.py
@@ -14,9 +14,9 @@
 
 import jax
 import jax.numpy as jnp
-from chex import dataclass
 
 import pgx.core as core
+from pgx._flax.struct import dataclass
 
 FALSE = jnp.bool_(False)
 TRUE = jnp.bool_(True)

--- a/pgx/leduc_holdem.py
+++ b/pgx/leduc_holdem.py
@@ -14,9 +14,9 @@
 
 import jax
 import jax.numpy as jnp
-from chex import dataclass
 
 import pgx.core as core
+from pgx._flax.struct import dataclass
 
 FALSE = jnp.bool_(False)
 TRUE = jnp.bool_(True)

--- a/pgx/minatar/asterix.py
+++ b/pgx/minatar/asterix.py
@@ -9,10 +9,10 @@ The original MinAtar implementation is distributed under GNU General Public Lice
 from typing import Literal, Optional
 
 import jax
-from chex import dataclass
 from jax import numpy as jnp
 
 import pgx.core as core
+from pgx._flax.struct import dataclass
 
 ramp_interval: jnp.ndarray = jnp.array(100, dtype=jnp.int32)
 init_spawn_speed: jnp.ndarray = jnp.array(10, dtype=jnp.int32)

--- a/pgx/minatar/breakout.py
+++ b/pgx/minatar/breakout.py
@@ -15,10 +15,10 @@ The original MinAtar implementation is distributed under GNU General Public Lice
 from typing import Literal, Optional
 
 import jax
-from chex import dataclass
 from jax import numpy as jnp
 
 import pgx.core as core
+from pgx._flax.struct import dataclass
 
 FALSE = jnp.bool_(False)
 TRUE = jnp.bool_(True)

--- a/pgx/minatar/freeway.py
+++ b/pgx/minatar/freeway.py
@@ -11,10 +11,10 @@ The original MinAtar implementation is distributed under GNU General Public Lice
 from typing import Literal, Optional
 
 import jax
-from chex import dataclass
 from jax import numpy as jnp
 
 import pgx.core as core
+from pgx._flax.struct import dataclass
 
 player_speed = jnp.array(3, dtype=jnp.int32)
 time_limit = jnp.array(2500, dtype=jnp.int32)

--- a/pgx/minatar/seaquest.py
+++ b/pgx/minatar/seaquest.py
@@ -10,10 +10,10 @@ from typing import Literal, Optional
 
 import jax
 import jax.lax as lax
-from chex import dataclass
 from jax import numpy as jnp
 
 import pgx.core as core
+from pgx._flax.struct import dataclass
 
 RAMP_INTERVAL: jnp.ndarray = jnp.int32(100)
 MAX_OXYGEN: jnp.ndarray = jnp.int32(200)

--- a/pgx/minatar/space_invaders.py
+++ b/pgx/minatar/space_invaders.py
@@ -12,10 +12,10 @@ from typing import Literal, Optional
 
 import jax
 import jax.lax as lax
-from chex import dataclass
 from jax import numpy as jnp
 
 import pgx.core as core
+from pgx._flax.struct import dataclass
 
 FALSE = jnp.bool_(False)
 TRUE = jnp.bool_(True)

--- a/pgx/othello.py
+++ b/pgx/othello.py
@@ -14,9 +14,9 @@
 
 import jax
 import jax.numpy as jnp
-from chex import dataclass
 
 import pgx.core as core
+from pgx._flax.struct import dataclass
 
 FALSE = jnp.bool_(False)
 TRUE = jnp.bool_(True)

--- a/pgx/play2048.py
+++ b/pgx/play2048.py
@@ -15,9 +15,9 @@
 
 import jax
 import jax.numpy as jnp
-from chex import dataclass
 
 import pgx.core as core
+from pgx._flax.struct import dataclass
 
 FALSE = jnp.bool_(False)
 TRUE = jnp.bool_(True)

--- a/pgx/shogi.py
+++ b/pgx/shogi.py
@@ -17,9 +17,9 @@ from functools import partial
 
 import jax
 import jax.numpy as jnp
-from chex import dataclass
 
 import pgx.core as core
+from pgx._flax.struct import dataclass
 from pgx._shogi_utils import (
     AROUND_IX,
     BETWEEN_IX,

--- a/pgx/sparrow_mahjong.py
+++ b/pgx/sparrow_mahjong.py
@@ -36,9 +36,9 @@ Pgx実装での違い
 import jax
 import jax.lax as lax
 import jax.numpy as jnp
-from chex import dataclass
 
 import pgx.core as core
+from pgx._flax.struct import dataclass
 
 TRUE = jnp.bool_(True)
 FALSE = jnp.bool_(False)

--- a/pgx/tic_tac_toe.py
+++ b/pgx/tic_tac_toe.py
@@ -14,9 +14,9 @@
 
 import jax
 import jax.numpy as jnp
-from chex import dataclass
 
 import pgx.core as core
+from pgx._flax.struct import dataclass
 
 FALSE = jnp.bool_(False)
 TRUE = jnp.bool_(True)

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ setup(
     include_package_data=True,
     install_requires=[
         "jax>=0.3.25",  # JAX version on Colab (TPU)
-        "chex>=0.1.6",
         "svgwrite",
         "msgpack",
         "typing_extensions"

--- a/workspace/how_to_develop/README.md
+++ b/workspace/how_to_develop/README.md
@@ -506,7 +506,7 @@ def f(n):
   * 実装がJit化可能かどうか検証・修正します。
 * (2) `jax.numpy` に書き換える
   * `import numpy as np` を `import jax.numpy as jnp` とします。
-  * `State` クラスを `chex.dataclass` にします。
+  * `State` クラスを `flax.struct.dataclass` にします。
   * in-placeな配列操作を `at` を使って書き換えます。
 * (3) `jax.jit` 可能な形に書き換える
   * テストが通ることを確認しつつ `@jax.jit` を `def` の上に一つずつ付けていく。


### PR DESCRIPTION
Reverts sotetsuk/pgx#787

#743

I found that #787 changes raise errors at least in two environments:

- Colab TPU
- M1 Mac

I will revert it and we will use the copied flax dataclass. It's very stable.