### PR TITLE
[API] Revert `auto_reset` argument

### DIFF
--- a/pgx/animal_shogi.py
+++ b/pgx/animal_shogi.py
@@ -79,8 +79,8 @@ class Action:
 
 
 class AnimalShogi(v1.Env):
-    def __init__(self, *, auto_reset: bool = False):
-        super().__init__(auto_reset=auto_reset)
+    def __init__(self):
+        super().__init__()
         self.max_termination_steps: int = 200
 
     def _init(self, key: jax.random.KeyArray) -> State:

--- a/pgx/backgammon.py
+++ b/pgx/backgammon.py
@@ -54,8 +54,8 @@ class State(v1.State):
 
 
 class Backgammon(v1.Env):
-    def __init__(self, *, auto_reset: bool = False):
-        super().__init__(auto_reset=auto_reset)
+    def __init__(self):
+        super().__init__()
 
     def _init(self, key: jax.random.KeyArray) -> State:
         return _init(key)

--- a/pgx/bridge_bidding.py
+++ b/pgx/bridge_bidding.py
@@ -93,10 +93,9 @@ class BridgeBidding(v1.Env):
     def __init__(
         self,
         *,
-        auto_reset: bool = False,
         dds_hash_table_path: Optional[str] = None
     ):
-        super().__init__(auto_reset=auto_reset)
+        super().__init__()
         if dds_hash_table_path is None:
             dds_hash_table_path = os.path.join(
                 os.getcwd(), "dds_hash_table.npz"

--- a/pgx/bridge_bidding.py
+++ b/pgx/bridge_bidding.py
@@ -90,11 +90,7 @@ class State(v1.State):
 
 
 class BridgeBidding(v1.Env):
-    def __init__(
-        self,
-        *,
-        dds_hash_table_path: Optional[str] = None
-    ):
+    def __init__(self, *, dds_hash_table_path: Optional[str] = None):
         super().__init__()
         if dds_hash_table_path is None:
             dds_hash_table_path = os.path.join(

--- a/pgx/chess.py
+++ b/pgx/chess.py
@@ -183,8 +183,8 @@ class Action:
 
 
 class Chess(v1.Env):
-    def __init__(self, *, auto_reset: bool = False):
-        super().__init__(auto_reset=auto_reset)
+    def __init__(self):
+        super().__init__()
         # AlphaZero paper does not mention the number of max termination steps
         # but we believe 1000 is large enough for Chess.
         self.max_termination_steps = 1000

--- a/pgx/connect_four.py
+++ b/pgx/connect_four.py
@@ -49,8 +49,8 @@ class State(v1.State):
 
 
 class ConnectFour(v1.Env):
-    def __init__(self, *, auto_reset: bool = False):
-        super().__init__(auto_reset=auto_reset)
+    def __init__(self):
+        super().__init__()
 
     def _init(self, key: jax.random.KeyArray) -> State:
         return _init(key)

--- a/pgx/go.py
+++ b/pgx/go.py
@@ -62,12 +62,11 @@ class Go(v1.Env):
     def __init__(
         self,
         *,
-        auto_reset: bool = False,
         size: int = 19,
         komi: float = 7.5,
         history_length: int = 8,
     ):
-        super().__init__(auto_reset=auto_reset)
+        super().__init__()
         assert isinstance(size, int)
         self.size = size
         self.komi = komi

--- a/pgx/hex.py
+++ b/pgx/hex.py
@@ -54,8 +54,8 @@ class State(v1.State):
 
 
 class Hex(v1.Env):
-    def __init__(self, *, size: int = 11, auto_reset: bool = False):
-        super().__init__(auto_reset=auto_reset)
+    def __init__(self, *, size: int = 11):
+        super().__init__()
         assert isinstance(size, int)
         self.size = size
 

--- a/pgx/kuhn_poker.py
+++ b/pgx/kuhn_poker.py
@@ -48,8 +48,8 @@ class State(v1.State):
 
 
 class KuhnPoker(v1.Env):
-    def __init__(self, *, auto_reset: bool = False):
-        super().__init__(auto_reset=auto_reset)
+    def __init__(self):
+        super().__init__()
 
     def _init(self, key: jax.random.KeyArray) -> State:
         return _init(key)

--- a/pgx/leduc_holdem.py
+++ b/pgx/leduc_holdem.py
@@ -54,8 +54,8 @@ class State(v1.State):
 
 
 class LeducHoldem(v1.Env):
-    def __init__(self, *, auto_reset: bool = False):
-        super().__init__(auto_reset=auto_reset)
+    def __init__(self):
+        super().__init__()
 
     def _init(self, key: jax.random.KeyArray) -> State:
         return _init(key)

--- a/pgx/minatar/asterix.py
+++ b/pgx/minatar/asterix.py
@@ -77,11 +77,10 @@ class MinAtarAsterix(v1.Env):
     def __init__(
         self,
         *,
-        auto_reset: bool = False,
         use_minimal_action_set: bool = True,
         sticky_action_prob: float = 0.1,
     ):
-        super().__init__(auto_reset=auto_reset)
+        super().__init__()
         self.use_minimal_action_set = use_minimal_action_set
         self.sticky_action_prob: float = sticky_action_prob
         self.minimal_action_set = jnp.int32([0, 1, 2, 3, 4])

--- a/pgx/minatar/breakout.py
+++ b/pgx/minatar/breakout.py
@@ -72,11 +72,10 @@ class MinAtarBreakout(v1.Env):
     def __init__(
         self,
         *,
-        auto_reset: bool = False,
         use_minimal_action_set: bool = True,
         sticky_action_prob: float = 0.1,
     ):
-        super().__init__(auto_reset=auto_reset)
+        super().__init__()
         self.use_minimal_action_set = use_minimal_action_set
         self.sticky_action_prob: float = sticky_action_prob
         self.minimal_action_set = jnp.int32([0, 1, 3])

--- a/pgx/minatar/freeway.py
+++ b/pgx/minatar/freeway.py
@@ -66,11 +66,10 @@ class MinAtarFreeway(v1.Env):
     def __init__(
         self,
         *,
-        auto_reset: bool = False,
         use_minimal_action_set: bool = True,
         sticky_action_prob: float = 0.1,
     ):
-        super().__init__(auto_reset=auto_reset)
+        super().__init__()
         self.use_minimal_action_set = use_minimal_action_set
         self.sticky_action_prob: float = sticky_action_prob
         self.minimal_action_set = jnp.int32([0, 2, 4])

--- a/pgx/minatar/seaquest.py
+++ b/pgx/minatar/seaquest.py
@@ -89,11 +89,10 @@ class MinAtarSeaquest(v1.Env):
     def __init__(
         self,
         *,
-        auto_reset: bool = False,
         use_minimal_action_set: bool = True,
         sticky_action_prob: float = 0.1,
     ):
-        super().__init__(auto_reset=auto_reset)
+        super().__init__()
         self.use_minimal_action_set = use_minimal_action_set
         self.sticky_action_prob: float = sticky_action_prob
         self.minimal_action_set = jnp.int32([0, 1, 2, 3, 4, 5])

--- a/pgx/minatar/space_invaders.py
+++ b/pgx/minatar/space_invaders.py
@@ -76,11 +76,10 @@ class MinAtarSpaceInvaders(v1.Env):
     def __init__(
         self,
         *,
-        auto_reset: bool = False,
         use_minimal_action_set: bool = True,
         sticky_action_prob: float = 0.1,
     ):
-        super().__init__(auto_reset=auto_reset)
+        super().__init__()
         self.use_minimal_action_set = use_minimal_action_set
         self.sticky_action_prob: float = sticky_action_prob
         self.minimal_action_set = jnp.int32([0, 1, 3, 5])

--- a/pgx/othello.py
+++ b/pgx/othello.py
@@ -51,8 +51,8 @@ class State(v1.State):
 
 
 class Othello(v1.Env):
-    def __init__(self, *, auto_reset: bool = False):
-        super().__init__(auto_reset=auto_reset)
+    def __init__(self):
+        super().__init__()
 
     def _init(self, key: jax.random.KeyArray) -> State:
         return _init(key)

--- a/pgx/play2048.py
+++ b/pgx/play2048.py
@@ -59,8 +59,8 @@ class State(v1.State):
 
 
 class Play2048(v1.Env):
-    def __init__(self, *, auto_reset: bool = False):
-        super().__init__(auto_reset=auto_reset)
+    def __init__(self):
+        super().__init__()
 
     def _init(self, key: jax.random.KeyArray) -> State:
         return _init(key)

--- a/pgx/shogi.py
+++ b/pgx/shogi.py
@@ -114,9 +114,7 @@ class State(v1.State):
 
 
 class Shogi(v1.Env):
-    def __init__(
-        self, *, max_termination_steps: int = 1000
-    ):
+    def __init__(self, *, max_termination_steps: int = 1000):
         super().__init__()
         self.max_termination_steps = max_termination_steps
 

--- a/pgx/shogi.py
+++ b/pgx/shogi.py
@@ -115,9 +115,9 @@ class State(v1.State):
 
 class Shogi(v1.Env):
     def __init__(
-        self, *, auto_reset: bool = False, max_termination_steps: int = 1000
+        self, *, max_termination_steps: int = 1000
     ):
-        super().__init__(auto_reset=auto_reset)
+        super().__init__()
         self.max_termination_steps = max_termination_steps
 
     def _init(self, key: jax.random.KeyArray) -> State:

--- a/pgx/sparrow_mahjong.py
+++ b/pgx/sparrow_mahjong.py
@@ -93,8 +93,8 @@ class State(v1.State):
 
 
 class SparrowMahjong(v1.Env):
-    def __init__(self, *, auto_reset: bool = False):
-        super().__init__(auto_reset=auto_reset)
+    def __init__(self):
+        super().__init__()
 
     def _init(self, key: jax.random.KeyArray) -> State:
         key, subkey = jax.random.split(key)

--- a/pgx/tic_tac_toe.py
+++ b/pgx/tic_tac_toe.py
@@ -44,8 +44,8 @@ class State(v1.State):
 
 
 class TicTacToe(v1.Env):
-    def __init__(self, *, auto_reset: bool = False):
-        super().__init__(auto_reset=auto_reset)
+    def __init__(self):
+        super().__init__()
 
     def _init(self, key: jax.random.KeyArray) -> State:
         return _init(key)

--- a/pgx/v1.py
+++ b/pgx/v1.py
@@ -168,8 +168,8 @@ class Env(abc.ABC):
 
     """
 
-    def __init__(self, *, auto_reset: bool = False):
-        self.auto_reset = auto_reset
+    def __init__(self):
+        ...
 
     def init(self, key: jax.random.KeyArray) -> State:
         """Return the initial state. Note that no internal state of
@@ -192,17 +192,6 @@ class Env(abc.ABC):
         """Step function."""
         is_illegal = ~state.legal_action_mask[action]
         current_player = state.current_player
-
-        # auto reset
-        state = jax.lax.cond(
-            self.auto_reset & state.terminated,
-            lambda: state.replace(  # type: ignore
-                _step_count=jnp.int32(0),
-                terminated=FALSE,
-                reward=jnp.zeros_like(state.reward),
-            ),
-            lambda: state,
-        )
 
         # If the state is already terminated or truncated, environment does not take usual step,
         # but return the same state with zero-rewards for all players
@@ -232,30 +221,6 @@ class Env(abc.ABC):
 
         observation = self.observe(state, state.current_player)
         state = state.replace(observation=observation)  # type: ignore
-
-        # auto reset
-        state = jax.lax.cond(
-            self.auto_reset & state.terminated,
-            # state is replaced by initial state,
-            # but preserve (terminated, truncated, reward)
-            lambda: self.init(state._rng_key).replace(  # type: ignore
-                terminated=state.terminated,
-                reward=state.reward,
-            ),
-            lambda: state,
-        )
-        # NOTE on final observation
-        # When auto reset happened, the terminal (or truncated) observation is replaced by initial observation,
-        # This is NOT problematic if it's termination.
-        # However, when truncation happened, final observation might be used by agent (for bootstrap)
-        # So we have to preserve the final observation somewhere. For example, in Gymnasium,
-        #
-        # https://github.com/Farama-Foundation/Gymnasium/blob/main/gymnasium/wrappers/autoreset.py#L59
-        #
-        # However, currently, truncation does **NOT** actually happens in Pgx environments because
-        # all of Pgx environments (games) are finite-horizon and terminates within reasonable # of steps.
-        # (NOTE: Chess, Shogi, and Go have `max_termination_steps` parameter following AlphaZero paper)
-        # So we believe current implementation is sufficient (final observation is not necessary).
 
         return state
 
@@ -353,7 +318,7 @@ def available_games() -> Tuple[EnvId, ...]:
     return games
 
 
-def make(env_id: EnvId, *, auto_reset: bool = False):  # noqa: C901
+def make(env_id: EnvId):  # noqa: C901
     """Load the specified environment.
 
     !!! example "Example usage"
@@ -374,79 +339,79 @@ def make(env_id: EnvId, *, auto_reset: bool = False):  # noqa: C901
     if env_id == "2048":
         from pgx.play2048 import Play2048
 
-        return Play2048(auto_reset=auto_reset)
+        return Play2048()
     elif env_id == "animal_shogi":
         from pgx.animal_shogi import AnimalShogi
 
-        return AnimalShogi(auto_reset=auto_reset)
+        return AnimalShogi()
     elif env_id == "backgammon":
         from pgx.backgammon import Backgammon
 
-        return Backgammon(auto_reset=auto_reset)
+        return Backgammon()
     elif env_id == "chess":
         from pgx.chess import Chess
 
-        return Chess(auto_reset=auto_reset)
+        return Chess()
     elif env_id == "connect_four":
         from pgx.connect_four import ConnectFour
 
-        return ConnectFour(auto_reset=auto_reset)
+        return ConnectFour()
     elif env_id == "go_9x9":
         from pgx.go import Go
 
-        return Go(auto_reset=auto_reset, size=9, komi=7.5)
+        return Go(size=9, komi=7.5)
     elif env_id == "go_19x19":
         from pgx.go import Go
 
-        return Go(auto_reset=auto_reset, size=19, komi=7.5)
+        return Go(size=19, komi=7.5)
     elif env_id == "hex":
         from pgx.hex import Hex
 
-        return Hex(auto_reset=auto_reset)
+        return Hex()
     elif env_id == "kuhn_poker":
         from pgx.kuhn_poker import KuhnPoker
 
-        return KuhnPoker(auto_reset=auto_reset)
+        return KuhnPoker()
     elif env_id == "leduc_holdem":
         from pgx.leduc_holdem import LeducHoldem
 
-        return LeducHoldem(auto_reset=auto_reset)
+        return LeducHoldem()
     elif env_id == "minatar-asterix":
         from pgx.minatar.asterix import MinAtarAsterix
 
-        return MinAtarAsterix(auto_reset=auto_reset)
+        return MinAtarAsterix()
     elif env_id == "minatar-breakout":
         from pgx.minatar.breakout import MinAtarBreakout
 
-        return MinAtarBreakout(auto_reset=auto_reset)
+        return MinAtarBreakout()
     elif env_id == "minatar-freeway":
         from pgx.minatar.freeway import MinAtarFreeway
 
-        return MinAtarFreeway(auto_reset=auto_reset)
+        return MinAtarFreeway()
     elif env_id == "minatar-seaquest":
         from pgx.minatar.seaquest import MinAtarSeaquest
 
-        return MinAtarSeaquest(auto_reset=auto_reset)
+        return MinAtarSeaquest()
     elif env_id == "minatar-space_invaders":
         from pgx.minatar.space_invaders import MinAtarSpaceInvaders
 
-        return MinAtarSpaceInvaders(auto_reset=auto_reset)
+        return MinAtarSpaceInvaders()
     elif env_id == "othello":
         from pgx.othello import Othello
 
-        return Othello(auto_reset=auto_reset)
+        return Othello()
     elif env_id == "shogi":
         from pgx.shogi import Shogi
 
-        return Shogi(auto_reset=auto_reset)
+        return Shogi()
     elif env_id == "sparrow_mahjong":
         from pgx.sparrow_mahjong import SparrowMahjong
 
-        return SparrowMahjong(auto_reset=auto_reset)
+        return SparrowMahjong()
     elif env_id == "tic_tac_toe":
         from pgx.tic_tac_toe import TicTacToe
 
-        return TicTacToe(auto_reset=auto_reset)
+        return TicTacToe()
     else:
         available_envs = "\n".join(available_games())
         raise ValueError(


### PR DESCRIPTION
I misunderstood that no Pgx environment require the truncation but actually MinAtar suits may continue forever.
So we remove `auto_reset` implementation, which replace the last state.
This `auto_reset` is not appropriate when the truncation happens (as bootstrap is impossible)