### PR TITLE
[2048] Fix reward overflow

### DIFF
--- a/pgx/play2048.py
+++ b/pgx/play2048.py
@@ -35,7 +35,6 @@ class State(v1.State):
     _rng_key: jax.random.KeyArray = jax.random.PRNGKey(0)
     _step_count: jnp.ndarray = jnp.int32(0)
     # --- 2048 specific ---
-    _turn: jnp.ndarray = jnp.int8(0)
     # 4x4 board
     # [[ 0,  1,  2,  3],
     #  [ 4,  5,  6,  7],

--- a/pgx/play2048.py
+++ b/pgx/play2048.py
@@ -41,7 +41,7 @@ class State(v1.State):
     #  [ 4,  5,  6,  7],
     #  [ 8,  9, 10, 11],
     #  [12, 13, 14, 15]]
-    _board: jnp.ndarray = jnp.zeros(16, jnp.int8)
+    _board: jnp.ndarray = jnp.zeros(16, jnp.int32)
     #  Board is expressed as a power of 2.
     # e.g.
     # [[ 0,  0,  1,  1],
@@ -89,7 +89,7 @@ class Play2048(v1.Env):
 
 def _init(rng: jax.random.KeyArray) -> State:
     rng1, rng2 = jax.random.split(rng)
-    board = _add_random_num(jnp.zeros((4, 4), jnp.int8), rng1)
+    board = _add_random_num(jnp.zeros((4, 4), jnp.int32), rng1)
     board = _add_random_num(board, rng2)
     return State(_board=board.ravel())  # type:ignore
 
@@ -156,7 +156,7 @@ def _add_random_num(board_2d, key):
     key, sub_key = jax.random.split(key)
     pos = jax.random.choice(key, jnp.arange(16), p=(board_2d.ravel() == 0))
     set_num = jax.random.choice(
-        sub_key, jnp.int8([1, 2]), p=jnp.array([0.9, 0.1])
+        sub_key, jnp.int32([1, 2]), p=jnp.array([0.9, 0.1])
     )
     board_2d = board_2d.at[pos // 4, pos % 4].set(set_num)
     return board_2d

--- a/pgx/play2048.py
+++ b/pgx/play2048.py
@@ -80,7 +80,7 @@ class Play2048(v1.Env):
 
     @property
     def version(self) -> str:
-        return "v0"
+        return "v1"
 
     @property
     def num_players(self) -> int:

--- a/pgx/play2048.py
+++ b/pgx/play2048.py
@@ -21,7 +21,7 @@ from pgx._src.struct import dataclass
 
 FALSE = jnp.bool_(False)
 TRUE = jnp.bool_(True)
-ZERO = jnp.int8(0)
+ZERO = jnp.int32(0)
 
 
 @dataclass

--- a/tests/test_play2048.py
+++ b/tests/test_play2048.py
@@ -125,6 +125,7 @@ def test_random_play():
         key, sub_key = jax.random.split(key)
         action = jax.random.choice(sub_key, legal_actions)
         state = step(state, jnp.int16(action))
+        assert (state.rewards >= 0).all()
         done = state.terminated
 
 

--- a/tests/test_play2048.py
+++ b/tests/test_play2048.py
@@ -16,27 +16,27 @@ def test_init():
 
 
 def test_slide_and_merge():
-    line = jnp.int8([0, 2, 0, 2])
-    assert (slide_and_merge(line)[0] == jnp.int8([3, 0, 0, 0])).all()
+    line = jnp.int32([0, 2, 0, 2])
+    assert (slide_and_merge(line)[0] == jnp.int32([3, 0, 0, 0])).all()
 
-    line = jnp.int8([0, 2, 0, 1])
-    assert (slide_and_merge(line)[0] == jnp.int8([2, 1, 0, 0])).all()
+    line = jnp.int32([0, 2, 0, 1])
+    assert (slide_and_merge(line)[0] == jnp.int32([2, 1, 0, 0])).all()
 
-    line = jnp.int8([2, 2, 2, 2])
-    assert (slide_and_merge(line)[0] == jnp.int8([3, 3, 0, 0])).all()
+    line = jnp.int32([2, 2, 2, 2])
+    assert (slide_and_merge(line)[0] == jnp.int32([3, 3, 0, 0])).all()
 
-    line = jnp.int8([2, 0, 0, 2])
-    assert (slide_and_merge(line)[0] == jnp.int8([3, 0, 0, 0])).all()
+    line = jnp.int32([2, 0, 0, 2])
+    assert (slide_and_merge(line)[0] == jnp.int32([3, 0, 0, 0])).all()
 
-    line = jnp.int8([1, 4, 4, 5])
-    assert (slide_and_merge(line)[0] == jnp.int8([1, 5, 5, 0])).all()
+    line = jnp.int32([1, 4, 4, 5])
+    assert (slide_and_merge(line)[0] == jnp.int32([1, 5, 5, 0])).all()
 
-    board = jnp.int8([0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2])
+    board = jnp.int32([0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2])
     board_2d = board.reshape((4, 4))
     board_2d = jax.vmap(_slide_and_merge)(board_2d)[0]
     board_1d = board_2d.ravel()
     assert (
-        board_1d == jnp.int8([3, 0, 0, 0, 3, 0, 0, 0, 3, 0, 0, 0, 3, 0, 0, 0])
+        board_1d == jnp.int32([3, 0, 0, 0, 3, 0, 0, 0, 3, 0, 0, 0, 3, 0, 0, 0])
     ).all()
 
 
@@ -51,7 +51,7 @@ def test_step():
     """
     assert (
         state._board
-        == jnp.int8([0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0])
+        == jnp.int32([0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0])
     ).all()
 
     state = step(state, 3)  # down
@@ -63,12 +63,12 @@ def test_step():
     """
     assert (
         state._board
-        == jnp.int8([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 2, 0])
+        == jnp.int32([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 2, 0])
     ).all()
 
 
 def test_legal_action():
-    board = jnp.int8([0, 1, 2, 3, 2, 3, 4, 5, 3, 4, 5, 6, 4, 5, 6, 0])
+    board = jnp.int32([0, 1, 2, 3, 2, 3, 4, 5, 3, 4, 5, 6, 4, 5, 6, 0])
     state = State(_board=board)
     state = step(state, 0)
     """
@@ -82,7 +82,7 @@ def test_legal_action():
 
 
 def test_terminated():
-    board = jnp.int8([1, 2, 3, 4, 2, 3, 4, 5, 3, 4, 5, 6, 0, 4, 5, 6])
+    board = jnp.int32([1, 2, 3, 4, 2, 3, 4, 5, 3, 4, 5, 6, 0, 4, 5, 6])
     state = State(_board=board)
     state = step(state, 0)
     """

--- a/tests/test_play2048.py
+++ b/tests/test_play2048.py
@@ -116,17 +116,18 @@ def test_observe():
 
 
 def test_random_play():
-    key = jax.random.PRNGKey(0)
-    done = jnp.bool_(False)
-    key, sub_key = jax.random.split(key)
-    state = init(sub_key)
-    while not done:
-        legal_actions = jnp.where(state.legal_action_mask)[0]
+    for i in range(10):
+        key = jax.random.PRNGKey(i)
+        done = jnp.bool_(False)
         key, sub_key = jax.random.split(key)
-        action = jax.random.choice(sub_key, legal_actions)
-        state = step(state, jnp.int16(action))
-        assert (state.rewards >= 0).all()
-        done = state.terminated
+        state = init(sub_key)
+        while not done:
+            legal_actions = jnp.where(state.legal_action_mask)[0]
+            key, sub_key = jax.random.split(key)
+            action = jax.random.choice(sub_key, legal_actions)
+            state = step(state, jnp.int16(action))
+            assert (state.rewards >= 0).all()
+            done = state.terminated
 
 
 def test_api():


### PR DESCRIPTION
This state transition returns `-92` as reward due to overflow.
This PR changes `int8` to `int32` and update version to `v1`.

<img width="226" alt="image" src="https://github.com/sotetsuk/pgx/assets/5868442/59d9ecde-f239-44f7-99a9-50ef2e1ee2c6">

<img width="216" alt="image" src="https://github.com/sotetsuk/pgx/assets/5868442/bb22810f-5fbd-4fee-9914-aef1a34075f2">
