### PR TITLE
[API] Use `int32` instead of `int8/16`

### DIFF
--- a/pgx/_src/api_test.py
+++ b/pgx/_src/api_test.py
@@ -45,7 +45,7 @@ def api_test_single(env: Env, num: int = 100):
     - observe
       - Returns different observations when player_ids are different (except the initial state)
     - TODO: reward must be zero when step is called after terminated
-    - TODO: observation type (bool, int8 or int16) for efficiency; https://jax.readthedocs.io/en/latest/type_promotion.html
+    - TODO: observation type (bool, int32 or int16) for efficiency; https://jax.readthedocs.io/en/latest/type_promotion.html
     """
 
     init = jax.jit(env.init)
@@ -136,14 +136,14 @@ def _validate_init_reward(state: State):
 def _validate_state(state: State):
     """validate_state checks these items:
 
-    - current_player is int8
+    - current_player is int32
     - terminated is bool_
     - reward is float
     - legal_action_mask is bool_
-    - TODO: observation is bool_ or int8 (can promote to any other types)
+    - TODO: observation is bool_ or int32 (can promote to any other types)
     """
     assert state.env_id in get_args(EnvId)
-    assert state.current_player.dtype == jnp.int8, state.current_player.dtype
+    assert state.current_player.dtype == jnp.int32, state.current_player.dtype
     assert state.terminated.dtype == jnp.bool_, state.terminated.dtype
     assert state.rewards.dtype == jnp.float32, state.rewards.dtype
     assert (

--- a/pgx/_src/api_test.py
+++ b/pgx/_src/api_test.py
@@ -45,7 +45,7 @@ def api_test_single(env: Env, num: int = 100):
     - observe
       - Returns different observations when player_ids are different (except the initial state)
     - TODO: reward must be zero when step is called after terminated
-    - TODO: observation type (bool, int32 or int16) for efficiency; https://jax.readthedocs.io/en/latest/type_promotion.html
+    - TODO: observation type (bool, int32 or int32) for efficiency; https://jax.readthedocs.io/en/latest/type_promotion.html
     """
 
     init = jax.jit(env.init)

--- a/pgx/_src/chess_utils.py
+++ b/pgx/_src/chess_utils.py
@@ -2,8 +2,8 @@
 import jax.numpy as jnp
 import jax.random
 
-TO_MAP = -jnp.ones((64, 73), dtype=jnp.int8)
-PLANE_MAP = -jnp.ones((64, 64), dtype=jnp.int8)  # ignores underpromotion
+TO_MAP = -jnp.ones((64, 73), dtype=jnp.int32)
+PLANE_MAP = -jnp.ones((64, 64), dtype=jnp.int32)  # ignores underpromotion
 # underpromotiona
 for from_ in range(64):
     if (from_ % 8) not in (1, 6):
@@ -18,7 +18,7 @@ for from_ in range(64):
             # black
             # 2  6 14 22 30 38 46 54 62
             # 1  7 15 23 31 39 47 55 63
-            to = from_ + jnp.int8([+1, +9, -7])[dir_]
+            to = from_ + jnp.int32([+1, +9, -7])[dir_]
         if not (0 <= to < 64):
             continue
         TO_MAP = TO_MAP.at[from_, plane].set(to)
@@ -59,12 +59,12 @@ for from_ in range(64):
         c = c + dc[plane - 9]
         if r < 0 or r >= 8 or c < 0 or c >= 8:
             continue
-        to = jnp.int8(c * 8 + r)
+        to = jnp.int32(c * 8 + r)
         TO_MAP = TO_MAP.at[from_, plane].set(to)
-        PLANE_MAP = PLANE_MAP.at[from_, to].set(jnp.int8(plane))
+        PLANE_MAP = PLANE_MAP.at[from_, to].set(jnp.int32(plane))
 
 
-CAN_MOVE = -jnp.ones((7, 64, 27), jnp.int8)
+CAN_MOVE = -jnp.ones((7, 64, 27), jnp.int32)
 # usage: CAN_MOVE[piece, from_x, from_y]
 # CAN_MOVE[0, :, :] are all -1
 # Note that the board is not symmetric about the center (different from shogi)
@@ -87,7 +87,7 @@ for from_ in range(64):
         ):
             legal_dst.append(to)
     assert len(legal_dst) <= 8
-    CAN_MOVE = CAN_MOVE.at[1, from_, : len(legal_dst)].set(jnp.int8(legal_dst))
+    CAN_MOVE = CAN_MOVE.at[1, from_, : len(legal_dst)].set(jnp.int32(legal_dst))
 # KNIGHT
 for from_ in range(64):
     r0, c0 = from_ % 8, from_ // 8
@@ -99,7 +99,7 @@ for from_ in range(64):
         if jnp.abs(r1 - r0) == 2 and jnp.abs(c1 - c0) == 1:
             legal_dst.append(to)
     assert len(legal_dst) <= 27
-    CAN_MOVE = CAN_MOVE.at[2, from_, : len(legal_dst)].set(jnp.int8(legal_dst))
+    CAN_MOVE = CAN_MOVE.at[2, from_, : len(legal_dst)].set(jnp.int32(legal_dst))
 # BISHOP
 for from_ in range(64):
     r0, c0 = from_ % 8, from_ // 8
@@ -111,7 +111,7 @@ for from_ in range(64):
         if jnp.abs(r1 - r0) == jnp.abs(c1 - c0):
             legal_dst.append(to)
     assert len(legal_dst) <= 27
-    CAN_MOVE = CAN_MOVE.at[3, from_, : len(legal_dst)].set(jnp.int8(legal_dst))
+    CAN_MOVE = CAN_MOVE.at[3, from_, : len(legal_dst)].set(jnp.int32(legal_dst))
 # ROOK
 for from_ in range(64):
     r0, c0 = from_ % 8, from_ // 8
@@ -123,7 +123,7 @@ for from_ in range(64):
         if jnp.abs(r1 - r0) == 0 or jnp.abs(c1 - c0) == 0:
             legal_dst.append(to)
     assert len(legal_dst) <= 27
-    CAN_MOVE = CAN_MOVE.at[4, from_, : len(legal_dst)].set(jnp.int8(legal_dst))
+    CAN_MOVE = CAN_MOVE.at[4, from_, : len(legal_dst)].set(jnp.int32(legal_dst))
 # QUEEN
 for from_ in range(64):
     r0, c0 = from_ % 8, from_ // 8
@@ -137,7 +137,7 @@ for from_ in range(64):
         if jnp.abs(r1 - r0) == jnp.abs(c1 - c0):
             legal_dst.append(to)
     assert len(legal_dst) <= 27
-    CAN_MOVE = CAN_MOVE.at[5, from_, : len(legal_dst)].set(jnp.int8(legal_dst))
+    CAN_MOVE = CAN_MOVE.at[5, from_, : len(legal_dst)].set(jnp.int32(legal_dst))
 # KING
 for from_ in range(64):
     r0, c0 = from_ % 8, from_ // 8
@@ -154,11 +154,11 @@ for from_ in range(64):
     # if from_ == 39:
     #     legal_dst += [23, 55]
     assert len(legal_dst) <= 8
-    CAN_MOVE = CAN_MOVE.at[6, from_, : len(legal_dst)].set(jnp.int8(legal_dst))
+    CAN_MOVE = CAN_MOVE.at[6, from_, : len(legal_dst)].set(jnp.int32(legal_dst))
 
 assert (CAN_MOVE[0, :, :] == -1).all()
 
-CAN_MOVE_ANY = -jnp.ones((64, 35), jnp.int8)
+CAN_MOVE_ANY = -jnp.ones((64, 35), jnp.int32)
 for from_ in range(64):
     legal_dst = []
     for i in range(27):
@@ -170,12 +170,12 @@ for from_ in range(64):
         if to >= 0:
             legal_dst.append(to)
     CAN_MOVE_ANY = CAN_MOVE_ANY.at[from_, : len(legal_dst)].set(
-        jnp.int8(legal_dst)
+        jnp.int32(legal_dst)
     )
 
 
 # Between
-BETWEEN = -jnp.ones((64, 64, 6), dtype=jnp.int8)
+BETWEEN = -jnp.ones((64, 64, 6), dtype=jnp.int32)
 for from_ in range(64):
     for to in range(64):
         r0, c0 = from_ % 8, from_ // 8
@@ -197,7 +197,7 @@ for from_ in range(64):
                 break
             bet.append(c * 8 + r)
         assert len(bet) <= 6
-        BETWEEN = BETWEEN.at[from_, to, : len(bet)].set(jnp.int8(bet))
+        BETWEEN = BETWEEN.at[from_, to, : len(bet)].set(jnp.int32(bet))
 
 INIT_LEGAL_ACTION_MASK = jnp.zeros(64 * 73, dtype=jnp.bool_)
 # fmt: off
@@ -208,7 +208,7 @@ for ix in ixs:
 assert INIT_LEGAL_ACTION_MASK.shape == (64 * 73,)
 assert INIT_LEGAL_ACTION_MASK.sum() == 20
 
-INIT_POSSIBLE_PIECE_POSITIONS = jnp.int8(
+INIT_POSSIBLE_PIECE_POSITIONS = jnp.int32(
     [
         [0, 1, 8, 9, 16, 17, 24, 25, 32, 33, 40, 41, 48, 49, 56, 57],
         [0, 1, 8, 9, 16, 17, 24, 25, 32, 33, 40, 41, 48, 49, 56, 57],

--- a/pgx/_src/chess_utils.py
+++ b/pgx/_src/chess_utils.py
@@ -87,7 +87,9 @@ for from_ in range(64):
         ):
             legal_dst.append(to)
     assert len(legal_dst) <= 8
-    CAN_MOVE = CAN_MOVE.at[1, from_, : len(legal_dst)].set(jnp.int32(legal_dst))
+    CAN_MOVE = CAN_MOVE.at[1, from_, : len(legal_dst)].set(
+        jnp.int32(legal_dst)
+    )
 # KNIGHT
 for from_ in range(64):
     r0, c0 = from_ % 8, from_ // 8
@@ -99,7 +101,9 @@ for from_ in range(64):
         if jnp.abs(r1 - r0) == 2 and jnp.abs(c1 - c0) == 1:
             legal_dst.append(to)
     assert len(legal_dst) <= 27
-    CAN_MOVE = CAN_MOVE.at[2, from_, : len(legal_dst)].set(jnp.int32(legal_dst))
+    CAN_MOVE = CAN_MOVE.at[2, from_, : len(legal_dst)].set(
+        jnp.int32(legal_dst)
+    )
 # BISHOP
 for from_ in range(64):
     r0, c0 = from_ % 8, from_ // 8
@@ -111,7 +115,9 @@ for from_ in range(64):
         if jnp.abs(r1 - r0) == jnp.abs(c1 - c0):
             legal_dst.append(to)
     assert len(legal_dst) <= 27
-    CAN_MOVE = CAN_MOVE.at[3, from_, : len(legal_dst)].set(jnp.int32(legal_dst))
+    CAN_MOVE = CAN_MOVE.at[3, from_, : len(legal_dst)].set(
+        jnp.int32(legal_dst)
+    )
 # ROOK
 for from_ in range(64):
     r0, c0 = from_ % 8, from_ // 8
@@ -123,7 +129,9 @@ for from_ in range(64):
         if jnp.abs(r1 - r0) == 0 or jnp.abs(c1 - c0) == 0:
             legal_dst.append(to)
     assert len(legal_dst) <= 27
-    CAN_MOVE = CAN_MOVE.at[4, from_, : len(legal_dst)].set(jnp.int32(legal_dst))
+    CAN_MOVE = CAN_MOVE.at[4, from_, : len(legal_dst)].set(
+        jnp.int32(legal_dst)
+    )
 # QUEEN
 for from_ in range(64):
     r0, c0 = from_ % 8, from_ // 8
@@ -137,7 +145,9 @@ for from_ in range(64):
         if jnp.abs(r1 - r0) == jnp.abs(c1 - c0):
             legal_dst.append(to)
     assert len(legal_dst) <= 27
-    CAN_MOVE = CAN_MOVE.at[5, from_, : len(legal_dst)].set(jnp.int32(legal_dst))
+    CAN_MOVE = CAN_MOVE.at[5, from_, : len(legal_dst)].set(
+        jnp.int32(legal_dst)
+    )
 # KING
 for from_ in range(64):
     r0, c0 = from_ % 8, from_ // 8
@@ -154,7 +164,9 @@ for from_ in range(64):
     # if from_ == 39:
     #     legal_dst += [23, 55]
     assert len(legal_dst) <= 8
-    CAN_MOVE = CAN_MOVE.at[6, from_, : len(legal_dst)].set(jnp.int32(legal_dst))
+    CAN_MOVE = CAN_MOVE.at[6, from_, : len(legal_dst)].set(
+        jnp.int32(legal_dst)
+    )
 
 assert (CAN_MOVE[0, :, :] == -1).all()
 

--- a/pgx/_src/gardner_chess_utils.py
+++ b/pgx/_src/gardner_chess_utils.py
@@ -55,7 +55,9 @@ for from_ in range(25):
         if r1 - r0 == 1 and jnp.abs(c1 - c0) <= 1:
             legal_dst.append(to)
     assert len(legal_dst) <= 6, f"{from_=}, {to=}, {legal_dst=}"
-    CAN_MOVE = CAN_MOVE.at[1, from_, : len(legal_dst)].set(jnp.int32(legal_dst))
+    CAN_MOVE = CAN_MOVE.at[1, from_, : len(legal_dst)].set(
+        jnp.int32(legal_dst)
+    )
 # KNIGHT
 for from_ in range(25):
     r0, c0 = from_ % 5, from_ // 5
@@ -67,7 +69,9 @@ for from_ in range(25):
         if jnp.abs(r1 - r0) == 2 and jnp.abs(c1 - c0) == 1:
             legal_dst.append(to)
     assert len(legal_dst) <= 8
-    CAN_MOVE = CAN_MOVE.at[2, from_, : len(legal_dst)].set(jnp.int32(legal_dst))
+    CAN_MOVE = CAN_MOVE.at[2, from_, : len(legal_dst)].set(
+        jnp.int32(legal_dst)
+    )
 # BISHOP
 for from_ in range(25):
     r0, c0 = from_ % 5, from_ // 5
@@ -79,7 +83,9 @@ for from_ in range(25):
         if jnp.abs(r1 - r0) == jnp.abs(c1 - c0):
             legal_dst.append(to)
     assert len(legal_dst) <= 8
-    CAN_MOVE = CAN_MOVE.at[3, from_, : len(legal_dst)].set(jnp.int32(legal_dst))
+    CAN_MOVE = CAN_MOVE.at[3, from_, : len(legal_dst)].set(
+        jnp.int32(legal_dst)
+    )
 # ROOK
 for from_ in range(25):
     r0, c0 = from_ % 5, from_ // 5
@@ -91,7 +97,9 @@ for from_ in range(25):
         if jnp.abs(r1 - r0) == 0 or jnp.abs(c1 - c0) == 0:
             legal_dst.append(to)
     assert len(legal_dst) <= 8
-    CAN_MOVE = CAN_MOVE.at[4, from_, : len(legal_dst)].set(jnp.int32(legal_dst))
+    CAN_MOVE = CAN_MOVE.at[4, from_, : len(legal_dst)].set(
+        jnp.int32(legal_dst)
+    )
 # QUEEN
 for from_ in range(25):
     r0, c0 = from_ % 5, from_ // 5
@@ -105,7 +113,9 @@ for from_ in range(25):
         if jnp.abs(r1 - r0) == jnp.abs(c1 - c0):
             legal_dst.append(to)
     assert len(legal_dst) <= 16
-    CAN_MOVE = CAN_MOVE.at[5, from_, : len(legal_dst)].set(jnp.int32(legal_dst))
+    CAN_MOVE = CAN_MOVE.at[5, from_, : len(legal_dst)].set(
+        jnp.int32(legal_dst)
+    )
 # KING
 for from_ in range(25):
     r0, c0 = from_ % 5, from_ // 5
@@ -117,7 +127,9 @@ for from_ in range(25):
         if (jnp.abs(r1 - r0) <= 1) and (jnp.abs(c1 - c0) <= 1):
             legal_dst.append(to)
     assert len(legal_dst) <= 8
-    CAN_MOVE = CAN_MOVE.at[6, from_, : len(legal_dst)].set(jnp.int32(legal_dst))
+    CAN_MOVE = CAN_MOVE.at[6, from_, : len(legal_dst)].set(
+        jnp.int32(legal_dst)
+    )
 
 assert (CAN_MOVE[0, :, :] == -1).all()
 

--- a/pgx/_src/gardner_chess_utils.py
+++ b/pgx/_src/gardner_chess_utils.py
@@ -2,8 +2,8 @@
 import jax
 import jax.numpy as jnp
 
-TO_MAP = -jnp.ones((25, 49), dtype=jnp.int8)
-PLANE_MAP = -jnp.ones((25, 25), dtype=jnp.int8)  # ignores underpromotions
+TO_MAP = -jnp.ones((25, 49), dtype=jnp.int32)
+PLANE_MAP = -jnp.ones((25, 25), dtype=jnp.int32)  # ignores underpromotions
 # underpromotions
 for from_ in range(25):
     if from_ % 5 != 3:  # 4th row in current player view
@@ -16,7 +16,7 @@ for from_ in range(25):
         # board index (flipped black view)
         # 5  0  5 10 15 20
         # 4  1  6 11 16 21
-        to = from_ + jnp.int8([+1, +6, -4])[dir_]
+        to = from_ + jnp.int32([+1, +6, -4])[dir_]
         if not (0 <= to < 25):
             continue
         TO_MAP = TO_MAP.at[from_, plane].set(to)
@@ -32,12 +32,12 @@ for from_ in range(25):
         c = c + dc[plane - 9]
         if r < 0 or r >= 5 or c < 0 or c >= 5:
             continue
-        to = jnp.int8(c * 5 + r)
+        to = jnp.int32(c * 5 + r)
         TO_MAP = TO_MAP.at[from_, plane].set(to)
-        PLANE_MAP = PLANE_MAP.at[from_, to].set(jnp.int8(plane))
+        PLANE_MAP = PLANE_MAP.at[from_, to].set(jnp.int32(plane))
 
 
-CAN_MOVE = -jnp.ones((7, 25, 16), jnp.int8)
+CAN_MOVE = -jnp.ones((7, 25, 16), jnp.int32)
 # usage: CAN_MOVE[piece, from_x, from_y]
 # CAN_MOVE[0, :, :] are all -1
 # Note that the board is not symmetric about the center (different from shogi)
@@ -55,7 +55,7 @@ for from_ in range(25):
         if r1 - r0 == 1 and jnp.abs(c1 - c0) <= 1:
             legal_dst.append(to)
     assert len(legal_dst) <= 6, f"{from_=}, {to=}, {legal_dst=}"
-    CAN_MOVE = CAN_MOVE.at[1, from_, : len(legal_dst)].set(jnp.int8(legal_dst))
+    CAN_MOVE = CAN_MOVE.at[1, from_, : len(legal_dst)].set(jnp.int32(legal_dst))
 # KNIGHT
 for from_ in range(25):
     r0, c0 = from_ % 5, from_ // 5
@@ -67,7 +67,7 @@ for from_ in range(25):
         if jnp.abs(r1 - r0) == 2 and jnp.abs(c1 - c0) == 1:
             legal_dst.append(to)
     assert len(legal_dst) <= 8
-    CAN_MOVE = CAN_MOVE.at[2, from_, : len(legal_dst)].set(jnp.int8(legal_dst))
+    CAN_MOVE = CAN_MOVE.at[2, from_, : len(legal_dst)].set(jnp.int32(legal_dst))
 # BISHOP
 for from_ in range(25):
     r0, c0 = from_ % 5, from_ // 5
@@ -79,7 +79,7 @@ for from_ in range(25):
         if jnp.abs(r1 - r0) == jnp.abs(c1 - c0):
             legal_dst.append(to)
     assert len(legal_dst) <= 8
-    CAN_MOVE = CAN_MOVE.at[3, from_, : len(legal_dst)].set(jnp.int8(legal_dst))
+    CAN_MOVE = CAN_MOVE.at[3, from_, : len(legal_dst)].set(jnp.int32(legal_dst))
 # ROOK
 for from_ in range(25):
     r0, c0 = from_ % 5, from_ // 5
@@ -91,7 +91,7 @@ for from_ in range(25):
         if jnp.abs(r1 - r0) == 0 or jnp.abs(c1 - c0) == 0:
             legal_dst.append(to)
     assert len(legal_dst) <= 8
-    CAN_MOVE = CAN_MOVE.at[4, from_, : len(legal_dst)].set(jnp.int8(legal_dst))
+    CAN_MOVE = CAN_MOVE.at[4, from_, : len(legal_dst)].set(jnp.int32(legal_dst))
 # QUEEN
 for from_ in range(25):
     r0, c0 = from_ % 5, from_ // 5
@@ -105,7 +105,7 @@ for from_ in range(25):
         if jnp.abs(r1 - r0) == jnp.abs(c1 - c0):
             legal_dst.append(to)
     assert len(legal_dst) <= 16
-    CAN_MOVE = CAN_MOVE.at[5, from_, : len(legal_dst)].set(jnp.int8(legal_dst))
+    CAN_MOVE = CAN_MOVE.at[5, from_, : len(legal_dst)].set(jnp.int32(legal_dst))
 # KING
 for from_ in range(25):
     r0, c0 = from_ % 5, from_ // 5
@@ -117,11 +117,11 @@ for from_ in range(25):
         if (jnp.abs(r1 - r0) <= 1) and (jnp.abs(c1 - c0) <= 1):
             legal_dst.append(to)
     assert len(legal_dst) <= 8
-    CAN_MOVE = CAN_MOVE.at[6, from_, : len(legal_dst)].set(jnp.int8(legal_dst))
+    CAN_MOVE = CAN_MOVE.at[6, from_, : len(legal_dst)].set(jnp.int32(legal_dst))
 
 assert (CAN_MOVE[0, :, :] == -1).all()
 
-CAN_MOVE_ANY = -jnp.ones((25, 24), jnp.int8)
+CAN_MOVE_ANY = -jnp.ones((25, 24), jnp.int32)
 for from_ in range(25):
     legal_dst = []
     for i in range(16):
@@ -134,10 +134,10 @@ for from_ in range(25):
             legal_dst.append(to)
     assert len(legal_dst) <= 24
     CAN_MOVE_ANY = CAN_MOVE_ANY.at[from_, : len(legal_dst)].set(
-        jnp.int8(legal_dst)
+        jnp.int32(legal_dst)
     )
 
-BETWEEN = -jnp.ones((25, 25, 3), dtype=jnp.int8)
+BETWEEN = -jnp.ones((25, 25, 3), dtype=jnp.int32)
 for from_ in range(25):
     for to in range(25):
         r0, c0 = from_ % 5, from_ // 5
@@ -159,7 +159,7 @@ for from_ in range(25):
                 break
             bet.append(c * 5 + r)
         assert len(bet) <= 3
-        BETWEEN = BETWEEN.at[from_, to, : len(bet)].set(jnp.int8(bet))
+        BETWEEN = BETWEEN.at[from_, to, : len(bet)].set(jnp.int32(bet))
 
 
 INIT_LEGAL_ACTION_MASK = jnp.zeros(25 * 49, dtype=jnp.bool_)

--- a/pgx/_src/shogi_utils.py
+++ b/pgx/_src/shogi_utils.py
@@ -19,7 +19,7 @@ import jax.numpy as jnp
 import numpy as np
 
 # fmt: off
-INIT_PIECE_BOARD = jnp.int8([[15, -1, 14, -1, -1, -1, 0, -1, 1],  # noqa: E241
+INIT_PIECE_BOARD = jnp.int32([[15, -1, 14, -1, -1, -1, 0, -1, 1],  # noqa: E241
                              [16, 18, 14, -1, -1, -1, 0,  5, 2],  # noqa: E241
                              [17, -1, 14, -1, -1, -1, 0, -1, 3],  # noqa: E241
                              [20, -1, 14, -1, -1, -1, 0, -1, 6],  # noqa: E241
@@ -148,8 +148,8 @@ assert INIT_LEGAL_ACTION_MASK.sum() == 30
 
 def _around(c):
     x, y = c // 9, c % 9
-    dx = jnp.int8([-1, -1, 0, +1, +1, +1, 0, -1])
-    dy = jnp.int8([0, -1, -1, -1, 0, +1, +1, +1])
+    dx = jnp.int32([-1, -1, 0, +1, +1, +1, 0, -1])
+    dy = jnp.int32([0, -1, -1, -1, 0, +1, +1, +1])
 
     def f(i):
         new_x, new_y = x + dx[i], y + dy[i]
@@ -237,7 +237,7 @@ def _from_sfen(sfen):
     # fmt: on
     board, turn, hand, step_count = sfen.split()
     board_ranks = board.split("/")
-    piece_board = jnp.zeros(81, dtype=jnp.int8)
+    piece_board = jnp.zeros(81, dtype=jnp.int32)
     for i in range(9):
         file = board_ranks[i]
         rank = []
@@ -255,7 +255,7 @@ def _from_sfen(sfen):
                 piece = 0
         for j in range(9):
             piece_board = piece_board.at[9 * i + j].set(rank[j])
-    s_hand = jnp.zeros(14, dtype=jnp.int8)
+    s_hand = jnp.zeros(14, dtype=jnp.int32)
     if hand != "-":
         num_piece = 1
         for char in hand:
@@ -266,5 +266,5 @@ def _from_sfen(sfen):
                 num_piece = 1
     piece_board = jnp.rot90(piece_board.reshape((9, 9)), k=1).flatten()
     hand = jnp.reshape(s_hand, (2, 7))
-    turn = jnp.int8(0) if turn == "b" else jnp.int8(1)
+    turn = jnp.int32(0) if turn == "b" else jnp.int32(1)
     return turn, piece_board, hand, int(step_count) - 1

--- a/pgx/animal_shogi.py
+++ b/pgx/animal_shogi.py
@@ -23,19 +23,19 @@ TRUE = jnp.bool_(True)
 FALSE = jnp.bool_(False)
 
 
-EMPTY = jnp.int8(-1)
-PAWN = jnp.int8(0)
-BISHOP = jnp.int8(1)
-ROOK = jnp.int8(2)
-KING = jnp.int8(3)
-GOLD = jnp.int8(4)
+EMPTY = jnp.int32(-1)
+PAWN = jnp.int32(0)
+BISHOP = jnp.int32(1)
+ROOK = jnp.int32(2)
+KING = jnp.int32(3)
+GOLD = jnp.int32(4)
 #  5: OPP_PAWN
 #  6: OPP_ROOK
 #  7: OPP_BISHOP
 #  8: OPP_KING
 #  9: OPP_GOLD
 # fmt: off
-INIT_BOARD = jnp.int8(
+INIT_BOARD = jnp.int32(
     [6, -1, -1, 2,
      8, 5, 0, 3,
      7, -1, -1, 1]
@@ -69,7 +69,7 @@ MAX_TERMINATION_STEPS = 256
 
 @dataclass
 class State(v1.State):
-    current_player: jnp.ndarray = jnp.int8(0)
+    current_player: jnp.ndarray = jnp.int32(0)
     rewards: jnp.ndarray = jnp.float32([0.0, 0.0])
     terminated: jnp.ndarray = FALSE
     truncated: jnp.ndarray = FALSE
@@ -78,9 +78,9 @@ class State(v1.State):
     _rng_key: jax.random.KeyArray = jax.random.PRNGKey(0)
     _step_count: jnp.ndarray = jnp.int32(0)
     # --- Animal Shogi specific ---
-    _turn: jnp.ndarray = jnp.int8(0)
+    _turn: jnp.ndarray = jnp.int32(0)
     _board: jnp.ndarray = INIT_BOARD  # (12,)
-    _hand: jnp.ndarray = jnp.zeros((2, 3), dtype=jnp.int8)
+    _hand: jnp.ndarray = jnp.zeros((2, 3), dtype=jnp.int32)
     _zobrist_hash: jnp.ndarray = jnp.uint32([233882788, 593924309])
     _hash_history: jnp.ndarray = (
         jnp.zeros((MAX_TERMINATION_STEPS + 1, 2), dtype=jnp.uint32)
@@ -88,10 +88,10 @@ class State(v1.State):
         .set(jnp.uint32([233882788, 593924309]))
     )
     _board_history: jnp.ndarray = (
-        (-jnp.ones((8, 12), dtype=jnp.int8)).at[0, :].set(INIT_BOARD)
+        (-jnp.ones((8, 12), dtype=jnp.int32)).at[0, :].set(INIT_BOARD)
     )
-    _hand_history: jnp.ndarray = jnp.zeros((8, 6), dtype=jnp.int8)
-    _rep_history: jnp.ndarray = jnp.zeros((8,), dtype=jnp.int8)
+    _hand_history: jnp.ndarray = jnp.zeros((8, 6), dtype=jnp.int32)
+    _rep_history: jnp.ndarray = jnp.zeros((8,), dtype=jnp.int32)
 
     @property
     def env_id(self) -> v1.EnvId:
@@ -101,9 +101,9 @@ class State(v1.State):
 @dataclass
 class Action:
     is_drop: jnp.ndarray = FALSE
-    from_: jnp.ndarray = jnp.int8(-1)
-    to: jnp.ndarray = jnp.int8(-1)
-    drop_piece: jnp.ndarray = jnp.int8(-1)
+    from_: jnp.ndarray = jnp.int32(-1)
+    to: jnp.ndarray = jnp.int32(-1)
+    drop_piece: jnp.ndarray = jnp.int32(-1)
 
     @staticmethod
     def _from_label(a: jnp.ndarray):
@@ -111,7 +111,7 @@ class Action:
         # 132 labels =
         #   [Move] 8 (direction) * 12 (from_) +
         #   [Drop] 3 (piece_type) * 12 (to)
-        x, sq = jnp.int8(a // 12), jnp.int8(a % 12)
+        x, sq = jnp.int32(a // 12), jnp.int32(a % 12)
         is_drop = 8 <= x
         return jax.lax.cond(
             is_drop,
@@ -126,7 +126,7 @@ class AnimalShogi(v1.Env):
 
     def _init(self, key: jax.random.KeyArray) -> State:
         rng, subkey = jax.random.split(key)
-        current_player = jnp.int8(jax.random.bernoulli(subkey))
+        current_player = jnp.int32(jax.random.bernoulli(subkey))
         state = State(current_player=current_player)  # type: ignore
         state = state.replace(legal_action_mask=_legal_action_mask(state))  # type: ignore
         return state
@@ -163,7 +163,7 @@ def _step(state: State, action: jnp.ndarray):
     a = Action._from_label(action)
     # apply move/drop action
     state = jax.lax.cond(a.is_drop, _step_drop, _step_move, *(state, a))
-    is_try = (state._board[jnp.int8([0, 4, 8])] == KING).any()
+    is_try = (state._board[jnp.int32([0, 4, 8])] == KING).any()
 
     # update board/hand history
     board_history = jnp.roll(state._board_history, 8)
@@ -182,7 +182,7 @@ def _step(state: State, action: jnp.ndarray):
 
     rep = (state._hash_history == state._zobrist_hash).any(
         axis=1
-    ).sum().astype(jnp.int8) - 1
+    ).sum().astype(jnp.int32) - 1
     is_rep_draw = rep >= 2
     legal_action_mask = _legal_action_mask(state)  # TODO: fix me
     terminated = (~legal_action_mask.any()) | is_try | is_rep_draw
@@ -404,12 +404,12 @@ def _to(from_, dir):
     # 6 x 1
     # 7 4 2
     x, y = from_ // 4, from_ % 4
-    dx = jnp.int8([-1, -1, -1, 0, 0, 1, 1, 1])
-    dy = jnp.int8([-1, 0, 1, -1, 1, -1, 0, 1])
+    dx = jnp.int32([-1, -1, -1, 0, 0, 1, 1, 1])
+    dy = jnp.int32([-1, 0, 1, -1, 1, -1, 0, 1])
     new_x = x + dx[dir]
     new_y = y + dy[dir]
     return jax.lax.select(
         (new_x < 0) | (new_x >= 3) | (new_y < 0) | (new_y >= 4),
-        jnp.int8(-1),
+        jnp.int32(-1),
         new_x * 4 + new_y,
     )

--- a/pgx/backgammon.py
+++ b/pgx/backgammon.py
@@ -26,8 +26,8 @@ FALSE = jnp.bool_(False)
 
 @dataclass
 class State(v1.State):
-    current_player: jnp.ndarray = jnp.int8(0)
-    observation: jnp.ndarray = jnp.zeros(34, dtype=jnp.int8)
+    current_player: jnp.ndarray = jnp.int32(0)
+    observation: jnp.ndarray = jnp.zeros(34, dtype=jnp.int32)
     rewards: jnp.ndarray = jnp.float32([0.0, 0.0])
     terminated: jnp.ndarray = FALSE
     truncated: jnp.ndarray = FALSE
@@ -37,13 +37,13 @@ class State(v1.State):
     _step_count: jnp.ndarray = jnp.int32(0)
     # --- Backgammon specific ---
     # points(24) bar(2) off(2). black+, white-
-    _board: jnp.ndarray = jnp.zeros(28, dtype=jnp.int8)
+    _board: jnp.ndarray = jnp.zeros(28, dtype=jnp.int32)
     _dice: jnp.ndarray = jnp.zeros(2, dtype=jnp.int16)  # 0~5: 1~6
     _playable_dice: jnp.ndarray = jnp.zeros(
         4, dtype=jnp.int16
     )  # playable dice -1 for empty
     _played_dice_num: jnp.ndarray = jnp.int16(0)  # the number of dice played
-    _turn: jnp.ndarray = jnp.int8(1)  # black: 0 white:1
+    _turn: jnp.ndarray = jnp.int32(1)  # black: 0 white:1
 
     @property
     def env_id(self) -> v1.EnvId:
@@ -84,7 +84,7 @@ class Backgammon(v1.Env):
 
 def _init(rng: jax.random.KeyArray) -> State:
     rng1, rng2, rng3 = jax.random.split(rng, num=3)
-    current_player: jnp.ndarray = jax.random.bernoulli(rng1).astype(jnp.int8)
+    current_player: jnp.ndarray = jax.random.bernoulli(rng1).astype(jnp.int32)
     board: jnp.ndarray = _make_init_board()
     terminated: jnp.ndarray = FALSE
     dice: jnp.ndarray = _roll_init_dice(rng2)
@@ -130,7 +130,7 @@ def _observe(state: State, player_id: jnp.ndarray) -> jnp.ndarray:
         player_id == state.current_player,
         lambda: jnp.concatenate((board, playable_dice_count_vec), axis=None),  # type: ignore
         lambda: jnp.concatenate(
-            (board, jnp.zeros(6, dtype=jnp.int8)), axis=None  # type: ignore
+            (board, jnp.zeros(6, dtype=jnp.int32)), axis=None  # type: ignore
         ),
     )
 
@@ -146,20 +146,20 @@ def _to_playable_dice_count(playable_dice: jnp.ndarray) -> jnp.ndarray:
     Return: [0, 0, 0, 0, 4, 0]
     """
     dice_indices: jnp.ndarray = jnp.array(
-        [0, 1, 2, 3], dtype=jnp.int8
+        [0, 1, 2, 3], dtype=jnp.int32
     )  # maximum number of playable dice is 4
 
     def _insert_dice_num(
         idx: jnp.ndarray, playable_dice: jnp.ndarray
     ) -> jnp.ndarray:
-        vec: jnp.ndarray = jnp.zeros(6, dtype=jnp.int8)
+        vec: jnp.ndarray = jnp.zeros(6, dtype=jnp.int32)
         return (playable_dice[idx] != -1) * vec.at[playable_dice[idx]].set(
             1
         ) + (playable_dice[idx] == -1) * vec
 
     return jax.vmap(_insert_dice_num)(
         dice_indices, jnp.tile(playable_dice, (4, 1))
-    ).sum(axis=0, dtype=jnp.int8)
+    ).sum(axis=0, dtype=jnp.int32)
 
 
 def _winning_step(
@@ -235,7 +235,7 @@ def _make_init_board() -> jnp.ndarray:
     """
     Initialize the board based on black's perspective.
     """
-    board: jnp.ndarray = jnp.array([2, 0, 0, 0, 0, -5, 0, -3, 0, 0, 0, 5, -5, 0, 0, 0, 3, 0, 5, 0, 0, 0, 0, -2, 0, 0, 0, 0], dtype=jnp.int8)  # type: ignore
+    board: jnp.ndarray = jnp.array([2, 0, 0, 0, 0, -5, 0, -3, 0, 0, 0, 5, -5, 0, 0, 0, 3, 0, 5, 0, 0, 0, 0, -2, 0, 0, 0, 0], dtype=jnp.int32)  # type: ignore
     return board
 
 
@@ -294,7 +294,7 @@ def _init_turn(dice: jnp.ndarray) -> jnp.ndarray:
     Begin with those who have bigger dice
     """
     diff = dice[1] - dice[0]
-    return jnp.int8(diff > 0)
+    return jnp.int32(diff > 0)
 
 
 def _set_playable_dice(dice: jnp.ndarray) -> jnp.ndarray:
@@ -338,7 +338,7 @@ def _home_board() -> jnp.ndarray:
     """
     black: [18~23], white: [0~5]: Always black's perspective
     """
-    return jnp.arange(18, 24, dtype=jnp.int8)  # type: ignore
+    return jnp.arange(18, 24, dtype=jnp.int32)  # type: ignore
 
 
 def _off_idx() -> int:

--- a/pgx/bridge_bidding.py
+++ b/pgx/bridge_bidding.py
@@ -102,7 +102,7 @@ class State(v1.State):
     legal_action_mask: jnp.ndarray = jnp.ones(38, dtype=jnp.bool_)
     _rng_key: jax.random.KeyArray = jax.random.PRNGKey(0)
     _step_count: jnp.ndarray = jnp.int32(0)
-    _turn: jnp.ndarray = jnp.int16(0)
+    _turn: jnp.ndarray = jnp.int32(0)
     _shuffled_players: jnp.ndarray = jnp.zeros(4, dtype=jnp.int32)
     # Hand of each player
     #   0  ~ 12: Hand of N
@@ -342,7 +342,7 @@ def _observe(state: State, player_id: jnp.ndarray) -> jnp.ndarray:
 
     # make hand of observation
     hand = jnp.zeros(52, dtype=jnp.bool_)
-    position = _player_position(player_id, state).astype(jnp.int16)
+    position = _player_position(player_id, state).astype(jnp.int32)
     hand = jax.lax.fori_loop(
         position * 13,
         (position + 1) * 13,

--- a/pgx/chess.py
+++ b/pgx/chess.py
@@ -38,13 +38,13 @@ MAX_TERMINATION_STEPS = 512  # from AZ paper
 TRUE = jnp.bool_(True)
 FALSE = jnp.bool_(False)
 
-EMPTY = jnp.int8(0)
-PAWN = jnp.int8(1)
-KNIGHT = jnp.int8(2)
-BISHOP = jnp.int8(3)
-ROOK = jnp.int8(4)
-QUEEN = jnp.int8(5)
-KING = jnp.int8(6)
+EMPTY = jnp.int32(0)
+PAWN = jnp.int32(1)
+KNIGHT = jnp.int32(2)
+BISHOP = jnp.int32(3)
+ROOK = jnp.int32(4)
+QUEEN = jnp.int32(5)
+KING = jnp.int32(6)
 # OPP_PAWN = -1
 # OPP_KNIGHT = -2
 # OPP_BISHOP = -3
@@ -74,7 +74,7 @@ KING = jnp.int8(6)
 # 1  7 15 23 31 39 47 55 63
 #    a  b  c  d  e  f  g  h
 # fmt: off
-INIT_BOARD = jnp.int8([
+INIT_BOARD = jnp.int32([
     4, 1, 0, 0, 0, 0, -1, -4,
     2, 1, 0, 0, 0, 0, -1, -2,
     3, 1, 0, 0, 0, 0, -1, -3,
@@ -113,7 +113,7 @@ INIT_BOARD = jnp.int8([
 
 @dataclass
 class State(v1.State):
-    current_player: jnp.ndarray = jnp.int8(0)
+    current_player: jnp.ndarray = jnp.int32(0)
     rewards: jnp.ndarray = jnp.float32([0.0, 0.0])
     terminated: jnp.ndarray = FALSE
     truncated: jnp.ndarray = FALSE
@@ -122,12 +122,12 @@ class State(v1.State):
     _rng_key: jax.random.KeyArray = jax.random.PRNGKey(0)
     _step_count: jnp.ndarray = jnp.int32(0)
     # --- Chess specific ---
-    _turn: jnp.ndarray = jnp.int8(0)
+    _turn: jnp.ndarray = jnp.int32(0)
     _board: jnp.ndarray = INIT_BOARD  # From top left. like FEN
     # (curr, opp) Flips every turn
     _can_castle_queen_side: jnp.ndarray = jnp.ones(2, dtype=jnp.bool_)
     _can_castle_king_side: jnp.ndarray = jnp.ones(2, dtype=jnp.bool_)
-    _en_passant: jnp.ndarray = jnp.int8(-1)  # En passant target. Flips.
+    _en_passant: jnp.ndarray = jnp.int32(-1)  # En passant target. Flips.
     # # of moves since the last piece capture or pawn move
     _halfmove_count: jnp.ndarray = jnp.int32(0)
     _fullmove_count: jnp.ndarray = jnp.int32(1)  # increase every black move
@@ -138,7 +138,7 @@ class State(v1.State):
         .set(INIT_ZOBRIST_HASH)
     )
     _board_history: jnp.ndarray = (
-        jnp.zeros((8, 64), dtype=jnp.int8).at[0, :].set(INIT_BOARD)
+        jnp.zeros((8, 64), dtype=jnp.int32).at[0, :].set(INIT_BOARD)
     )
     # index to possible piece positions for speeding up. Flips every turn.
     _possible_piece_positions: jnp.ndarray = INIT_POSSIBLE_PIECE_POSITIONS
@@ -157,9 +157,9 @@ class State(v1.State):
 
 @dataclass
 class Action:
-    from_: jnp.ndarray = jnp.int8(-1)
-    to: jnp.ndarray = jnp.int8(-1)
-    underpromotion: jnp.ndarray = jnp.int8(-1)  # 0: rook, 1: bishop, 2: knight
+    from_: jnp.ndarray = jnp.int32(-1)
+    to: jnp.ndarray = jnp.int32(-1)
+    underpromotion: jnp.ndarray = jnp.int32(-1)  # 0: rook, 1: bishop, 2: knight
 
     @staticmethod
     def _from_label(label: jnp.ndarray):
@@ -183,7 +183,7 @@ class Action:
             from_=from_,
             to=TO_MAP[from_, plane],  # -1 if impossible move
             underpromotion=jax.lax.select(
-                plane >= 9, jnp.int8(-1), jnp.int8(plane // 3)
+                plane >= 9, jnp.int32(-1), jnp.int32(plane // 3)
             ),
         )
 
@@ -199,7 +199,7 @@ class Chess(v1.Env):
 
     def _init(self, key: jax.random.KeyArray) -> State:
         rng, subkey = jax.random.split(key)
-        current_player = jnp.int8(jax.random.bernoulli(subkey))
+        current_player = jnp.int32(jax.random.bernoulli(subkey))
         state = State(current_player=current_player)  # type: ignore
         return state
 
@@ -335,8 +335,8 @@ def _apply_move(state: State, a: Action):
     state = state.replace(  # type: ignore
         _en_passant=jax.lax.select(
             (piece == PAWN) & (jnp.abs(a.to - a.from_) == 2),
-            jnp.int8((a.to + a.from_) // 2),
-            jnp.int8(-1),
+            jnp.int32((a.to + a.from_) // 2),
+            jnp.int32(-1),
         )
     )
     # update counters
@@ -422,7 +422,7 @@ def _apply_move(state: State, a: Action):
     piece = jax.lax.select(
         a.underpromotion < 0,
         piece,
-        jnp.int8([ROOK, BISHOP, KNIGHT])[a.underpromotion],
+        jnp.int32([ROOK, BISHOP, KNIGHT])[a.underpromotion],
     )
     # actually move
     state = state.replace(  # type: ignore
@@ -440,12 +440,12 @@ def _apply_move(state: State, a: Action):
 
 def _flip_pos(x):
     """
-    >>> _flip_pos(jnp.int8(34))
-    Array(37, dtype=int8)
-    >>> _flip_pos(jnp.int8(37))
-    Array(34, dtype=int8)
-    >>> _flip_pos(jnp.int8(-1))
-    Array(-1, dtype=int8)
+    >>> _flip_pos(jnp.int32(34))
+    Array(37, dtype=int32)
+    >>> _flip_pos(jnp.int32(37))
+    Array(34, dtype=int32)
+    >>> _flip_pos(jnp.int32(-1))
+    Array(-1, dtype=int32)
     """
     return jax.lax.select(x == -1, x, (x // 8) * 8 + (7 - (x % 8)))
 
@@ -632,11 +632,11 @@ def _is_pseudo_legal(state: State, a: Action):
 
 def _possible_piece_positions(state):
     my_pos = jnp.nonzero(state._board > 0, size=16, fill_value=-1)[0].astype(
-        jnp.int8
+        jnp.int32
     )
     opp_pos = jnp.nonzero(_flip(state)._board > 0, size=16, fill_value=-1)[
         0
-    ].astype(jnp.int8)
+    ].astype(jnp.int32)
     return jnp.vstack((my_pos, opp_pos))
 
 
@@ -782,9 +782,9 @@ def _from_fen(fen: str):
            [ 0,  0,  0,  0,  0,  0,  0,  0],
            [ 1,  0,  0,  0,  0,  0,  0,  0],
            [ 0,  1,  1,  1,  1,  1,  1,  1],
-           [ 4,  2,  3,  5,  6,  3,  2,  4]], dtype=int8)
+           [ 4,  2,  3,  5,  6,  3,  2,  4]], dtype=int32)
     >>> state._en_passant
-    Array(34, dtype=int8)
+    Array(34, dtype=int32)
     >>> state = _from_fen(
     ...     "rnbqkbnr/pppppppp/8/8/8/P7/1PPPPPPP/RNBQKBNR b KQkq e3 0 1"
     ... )
@@ -796,9 +796,9 @@ def _from_fen(fen: str):
            [ 0,  0,  0,  0,  0,  0,  0,  0],
            [ 0,  0,  0,  0,  0,  0,  0,  0],
            [ 1,  1,  1,  1,  1,  1,  1,  1],
-           [ 4,  2,  3,  5,  6,  3,  2,  4]], dtype=int8)
+           [ 4,  2,  3,  5,  6,  3,  2,  4]], dtype=int32)
     >>> state._en_passant
-    Array(37, dtype=int8)
+    Array(37, dtype=int32)
     """
     board, turn, castling, en_passant, halfmove_cnt, fullmove_cnt = fen.split()
     arr = []
@@ -825,13 +825,13 @@ def _from_fen(fen: str):
     if turn == "b":
         can_castle_queen_side = can_castle_queen_side[::-1]
         can_castle_king_side = can_castle_king_side[::-1]
-    mat = jnp.int8(arr).reshape(8, 8)
+    mat = jnp.int32(arr).reshape(8, 8)
     if turn == "b":
         mat = -jnp.flip(mat, axis=0)
     ep = (
-        jnp.int8(-1)
+        jnp.int32(-1)
         if en_passant == "-"
-        else jnp.int8(
+        else jnp.int32(
             "abcdefgh".index(en_passant[0]) * 8 + int(en_passant[1]) - 1
         )
     )
@@ -839,7 +839,7 @@ def _from_fen(fen: str):
         ep = _flip_pos(ep)
     state = State(  # type: ignore
         _board=jnp.rot90(mat, k=3).flatten(),
-        _turn=jnp.int8(0) if turn == "w" else jnp.int8(1),
+        _turn=jnp.int32(0) if turn == "w" else jnp.int32(1),
         _can_castle_queen_side=can_castle_queen_side,
         _can_castle_king_side=can_castle_king_side,
         _en_passant=ep,
@@ -875,7 +875,7 @@ def _to_fen(state: State):
     - The place where en passant is possible. If the pawn moves 2 squares, record the position where the pawn passed
     - At last, the number of moves since the last pawn move or capture and the normal number of moves (fixed at 0 and 1 here)
 
-    >>> s = State(_en_passant=jnp.int8(34))
+    >>> s = State(_en_passant=jnp.int32(34))
     >>> _to_fen(s)
     'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq e3 0 1'
     >>> _to_fen(

--- a/pgx/chess.py
+++ b/pgx/chess.py
@@ -159,7 +159,9 @@ class State(v1.State):
 class Action:
     from_: jnp.ndarray = jnp.int32(-1)
     to: jnp.ndarray = jnp.int32(-1)
-    underpromotion: jnp.ndarray = jnp.int32(-1)  # 0: rook, 1: bishop, 2: knight
+    underpromotion: jnp.ndarray = jnp.int32(
+        -1
+    )  # 0: rook, 1: bishop, 2: knight
 
     @staticmethod
     def _from_label(label: jnp.ndarray):

--- a/pgx/connect_four.py
+++ b/pgx/connect_four.py
@@ -24,7 +24,7 @@ TRUE = jnp.bool_(True)
 
 @dataclass
 class State(v1.State):
-    current_player: jnp.ndarray = jnp.int8(0)
+    current_player: jnp.ndarray = jnp.int32(0)
     observation: jnp.ndarray = jnp.zeros((6, 7, 2), dtype=jnp.bool_)
     rewards: jnp.ndarray = jnp.float32([0.0, 0.0])
     terminated: jnp.ndarray = FALSE
@@ -33,7 +33,7 @@ class State(v1.State):
     _rng_key: jax.random.KeyArray = jax.random.PRNGKey(0)
     _step_count: jnp.ndarray = jnp.int32(0)
     # --- Connect Four specific ---
-    _turn: jnp.ndarray = jnp.int8(0)
+    _turn: jnp.ndarray = jnp.int32(0)
     # 6x7 board
     # [[ 0,  1,  2,  3,  4,  5,  6],
     #  [ 7,  8,  9, 10, 11, 12, 13],
@@ -41,7 +41,7 @@ class State(v1.State):
     #  [21, 22, 23, 24, 25, 26, 27],
     #  [28, 29, 30, 31, 32, 33, 34],
     #  [35, 36, 37, 38, 39, 40, 41]]
-    _board: jnp.ndarray = -jnp.ones(42, jnp.int8)  # -1 (empty), 0, 1
+    _board: jnp.ndarray = -jnp.ones(42, jnp.int32)  # -1 (empty), 0, 1
     _blank_row: jnp.ndarray = jnp.full(7, 5)
 
     @property
@@ -99,7 +99,7 @@ def _make_win_cache():
         for j in range(3, 7):
             a = i * 7 + j
             idx.append([a, a + 6, a + 12, a + 18])
-    return jnp.int8(idx)
+    return jnp.int32(idx)
 
 
 IDX = _make_win_cache()
@@ -107,7 +107,7 @@ IDX = _make_win_cache()
 
 def _init(rng: jax.random.KeyArray) -> State:
     rng, subkey = jax.random.split(rng)
-    current_player = jnp.int8(jax.random.bernoulli(subkey))
+    current_player = jnp.int32(jax.random.bernoulli(subkey))
     return State(current_player=current_player)  # type:ignore
 
 
@@ -142,7 +142,7 @@ def _win_check(board, turn) -> jnp.ndarray:
 
 
 def _observe(state: State, player_id: jnp.ndarray) -> jnp.ndarray:
-    turns = jnp.int8([state._turn, 1 - state._turn])
+    turns = jnp.int32([state._turn, 1 - state._turn])
     turns = jax.lax.cond(
         player_id == state.current_player,
         lambda: turns,

--- a/pgx/experimental/bridge_bidding.py
+++ b/pgx/experimental/bridge_bidding.py
@@ -77,30 +77,30 @@ def _duplicate_init(
     >>> state = env.init(key)
     >>> duplicate_state = _duplicate_init(state)
     >>> duplicate_state._shuffled_players
-    Array([0, 2, 1, 3], dtype=int8)
+    Array([0, 2, 1, 3], dtype=int32)
     >>> duplicate_state._dealer
     Array(1, dtype=int32)
     >>> duplicate_state.current_player
-    Array(2, dtype=int8)
+    Array(2, dtype=int32)
     >>> state = env.step(state, 35)
     >>> duplicate_state = _duplicate_init(state)
     >>> duplicate_state._shuffled_players
-    Array([0, 2, 1, 3], dtype=int8)
+    Array([0, 2, 1, 3], dtype=int32)
     >>> duplicate_state._dealer
     Array(1, dtype=int32)
     >>> duplicate_state.current_player
-    Array(2, dtype=int8)
+    Array(2, dtype=int32)
     >>> duplicate_state._pass_num
     Array(0, dtype=int32)
 
     >>> state = env.step(state, 0)
     >>> duplicate_state = _duplicate_init(state)
     >>> duplicate_state._shuffled_players
-    Array([0, 2, 1, 3], dtype=int8)
+    Array([0, 2, 1, 3], dtype=int32)
     >>> duplicate_state._dealer
     Array(1, dtype=int32)
     >>> duplicate_state.current_player
-    Array(2, dtype=int8)
+    Array(2, dtype=int32)
     >>> duplicate_state.legal_action_mask
     Array([ True,  True,  True,  True,  True,  True,  True,  True,  True,
             True,  True,  True,  True,  True,  True,  True,  True,  True,

--- a/pgx/gardner_chess.py
+++ b/pgx/gardner_chess.py
@@ -141,7 +141,9 @@ class State(v1.State):
 class Action:
     from_: jnp.ndarray = jnp.int32(-1)
     to: jnp.ndarray = jnp.int32(-1)
-    underpromotion: jnp.ndarray = jnp.int32(-1)  # 0: rook, 1: bishop, 2: knight
+    underpromotion: jnp.ndarray = jnp.int32(
+        -1
+    )  # 0: rook, 1: bishop, 2: knight
 
     @staticmethod
     def _from_label(label: jnp.ndarray):

--- a/pgx/go.py
+++ b/pgx/go.py
@@ -38,7 +38,7 @@ class State(v1.State):
     _size: jnp.ndarray = jnp.int32(19)  # NOTE: require 19 * 19 > int32
     # ids of representative stone id (smallest) in the connected stones
     # positive for black, negative for white, and zero for empty.
-    # require at least 19 * 19 > int32, idx_squared_sum can be 361^2 > int16
+    # require at least 19 * 19 > int32, idx_squared_sum can be 361^2 > int32
     _chain_id_board: jnp.ndarray = jnp.zeros(19 * 19, dtype=jnp.int32)
     _board_history: jnp.ndarray = jnp.full((8, 19 * 19), 2, dtype=jnp.int32)
     _turn: jnp.ndarray = jnp.int32(0)  # 0 = black's turn, 1 = white's turn

--- a/pgx/hex.py
+++ b/pgx/hex.py
@@ -26,7 +26,7 @@ TRUE = jnp.bool_(True)
 
 @dataclass
 class State(v1.State):
-    current_player: jnp.ndarray = jnp.int8(0)
+    current_player: jnp.ndarray = jnp.int32(0)
     observation: jnp.ndarray = jnp.zeros((11, 11, 2), dtype=jnp.bool_)
     rewards: jnp.ndarray = jnp.float32([0.0, 0.0])
     terminated: jnp.ndarray = FALSE
@@ -37,9 +37,9 @@ class State(v1.State):
     _rng_key: jax.random.KeyArray = jax.random.PRNGKey(0)
     _step_count: jnp.ndarray = jnp.int32(0)
     # --- Hex specific ---
-    _size: jnp.ndarray = jnp.int8(11)
+    _size: jnp.ndarray = jnp.int32(11)
     # 0(black), 1(white)
-    _turn: jnp.ndarray = jnp.int8(0)
+    _turn: jnp.ndarray = jnp.int32(0)
     # 11x11 board
     # [[  0,  1,  2,  ...,  8,  9, 10],
     #  [ 11,  12, 13, ..., 19, 20, 21],
@@ -92,7 +92,7 @@ class Hex(v1.Env):
 
 def _init(rng: jax.random.KeyArray, size: int) -> State:
     rng, subkey = jax.random.split(rng)
-    current_player = jnp.int8(jax.random.bernoulli(subkey))
+    current_player = jnp.int32(jax.random.bernoulli(subkey))
     return State(_size=size, current_player=current_player)  # type:ignore
 
 

--- a/pgx/kuhn_poker.py
+++ b/pgx/kuhn_poker.py
@@ -20,15 +20,15 @@ from pgx._src.struct import dataclass
 
 FALSE = jnp.bool_(False)
 TRUE = jnp.bool_(True)
-CALL = jnp.int8(0)
-BET = jnp.int8(1)
-FOLD = jnp.int8(2)
-CHECK = jnp.int8(3)
+CALL = jnp.int32(0)
+BET = jnp.int32(1)
+FOLD = jnp.int32(2)
+CHECK = jnp.int32(3)
 
 
 @dataclass
 class State(v1.State):
-    current_player: jnp.ndarray = jnp.int8(0)
+    current_player: jnp.ndarray = jnp.int32(0)
     observation: jnp.ndarray = jnp.zeros((8, 8, 2), dtype=jnp.bool_)
     rewards: jnp.ndarray = jnp.float32([0.0, 0.0])
     terminated: jnp.ndarray = FALSE
@@ -37,11 +37,11 @@ class State(v1.State):
     _rng_key: jax.random.KeyArray = jax.random.PRNGKey(0)
     _step_count: jnp.ndarray = jnp.int32(0)
     # --- Kuhn poker specific ---
-    _cards: jnp.ndarray = jnp.int8([-1, -1])
+    _cards: jnp.ndarray = jnp.int32([-1, -1])
     # [(player 0),(player 1)]
-    _last_action: jnp.ndarray = jnp.int8(-1)
+    _last_action: jnp.ndarray = jnp.int32(-1)
     # 0(Call)  1(Bet)  2(Fold)  3(Check)
-    _pot: jnp.ndarray = jnp.int8([0, 0])
+    _pot: jnp.ndarray = jnp.int32([0, 0])
 
     @property
     def env_id(self) -> v1.EnvId:
@@ -78,9 +78,9 @@ class KuhnPoker(v1.Env):
 
 def _init(rng: jax.random.KeyArray) -> State:
     rng1, rng2 = jax.random.split(rng)
-    current_player = jnp.int8(jax.random.bernoulli(rng1))
+    current_player = jnp.int32(jax.random.bernoulli(rng1))
     init_card = jax.random.choice(
-        rng2, jnp.int8([[0, 1], [0, 2], [1, 0], [1, 2], [2, 0], [2, 1]])
+        rng2, jnp.int32([[0, 1], [0, 2], [1, 0], [1, 2], [2, 0], [2, 1]])
     )
     return State(  # type:ignore
         current_player=current_player,
@@ -90,7 +90,7 @@ def _init(rng: jax.random.KeyArray) -> State:
 
 
 def _step(state: State, action):
-    action = jnp.int8(action)
+    action = jnp.int32(action)
     pot = jax.lax.cond(
         (action == BET) | (action == CALL),
         lambda: state._pot.at[state.current_player].add(1),

--- a/pgx/leduc_holdem.py
+++ b/pgx/leduc_holdem.py
@@ -119,7 +119,9 @@ def _step(state: State, action):
         round_over, state._first_player, 1 - state.current_player
     )
     raise_count = jax.lax.select(
-        round_over, jnp.int32(0), state._raise_count + jnp.int32(action == RAISE)
+        round_over,
+        jnp.int32(0),
+        state._raise_count + jnp.int32(action == RAISE),
     )
 
     reward *= jnp.min(chips)

--- a/pgx/leduc_holdem.py
+++ b/pgx/leduc_holdem.py
@@ -21,17 +21,17 @@ from pgx._src.struct import dataclass
 FALSE = jnp.bool_(False)
 TRUE = jnp.bool_(True)
 
-INVALID_ACTION = jnp.int8(-1)
-CALL = jnp.int8(0)
-RAISE = jnp.int8(1)
-FOLD = jnp.int8(2)
+INVALID_ACTION = jnp.int32(-1)
+CALL = jnp.int32(0)
+RAISE = jnp.int32(1)
+FOLD = jnp.int32(2)
 
-MAX_RAISE = jnp.int8(2)
+MAX_RAISE = jnp.int32(2)
 
 
 @dataclass
 class State(v1.State):
-    current_player: jnp.ndarray = jnp.int8(0)
+    current_player: jnp.ndarray = jnp.int32(0)
     observation: jnp.ndarray = jnp.zeros((8, 8, 2), dtype=jnp.bool_)
     rewards: jnp.ndarray = jnp.float32([0.0, 0.0])
     terminated: jnp.ndarray = FALSE
@@ -40,14 +40,14 @@ class State(v1.State):
     _rng_key: jax.random.KeyArray = jax.random.PRNGKey(0)
     _step_count: jnp.ndarray = jnp.int32(0)
     # --- Leduc Hold'Em specific ---
-    _first_player: jnp.ndarray = jnp.int8(0)
+    _first_player: jnp.ndarray = jnp.int32(0)
     # [(player 0), (player 1), (public)]
-    _cards: jnp.ndarray = jnp.int8([-1, -1, -1])
+    _cards: jnp.ndarray = jnp.int32([-1, -1, -1])
     # 0(Call)  1(Bet)  2(Fold)  3(Check)
     _last_action: jnp.ndarray = INVALID_ACTION
-    _chips: jnp.ndarray = jnp.ones(2, dtype=jnp.int8)
-    _round: jnp.ndarray = jnp.int8(0)
-    _raise_count: jnp.ndarray = jnp.int8(0)
+    _chips: jnp.ndarray = jnp.ones(2, dtype=jnp.int32)
+    _round: jnp.ndarray = jnp.int32(0)
+    _raise_count: jnp.ndarray = jnp.int32(0)
 
     @property
     def env_id(self) -> v1.EnvId:
@@ -84,9 +84,9 @@ class LeducHoldem(v1.Env):
 
 def _init(rng: jax.random.KeyArray) -> State:
     rng1, rng2, rng3 = jax.random.split(rng, 3)
-    current_player = jnp.int8(jax.random.bernoulli(rng1))
+    current_player = jnp.int32(jax.random.bernoulli(rng1))
     init_card = jax.random.permutation(
-        rng2, jnp.int8([0, 0, 1, 1, 2, 2]), independent=True
+        rng2, jnp.int32([0, 0, 1, 1, 2, 2]), independent=True
     )
     return State(  # type:ignore
         _rng_key=rng3,
@@ -94,12 +94,12 @@ def _init(rng: jax.random.KeyArray) -> State:
         current_player=current_player,
         _cards=init_card[:3],
         legal_action_mask=jnp.bool_([1, 1, 0]),
-        _chips=jnp.ones(2, dtype=jnp.int8),
+        _chips=jnp.ones(2, dtype=jnp.int32),
     )
 
 
 def _step(state: State, action):
-    action = jnp.int8(action)
+    action = jnp.int32(action)
     chips = jax.lax.switch(
         action,
         [
@@ -119,7 +119,7 @@ def _step(state: State, action):
         round_over, state._first_player, 1 - state.current_player
     )
     raise_count = jax.lax.select(
-        round_over, jnp.int8(0), state._raise_count + jnp.int8(action == RAISE)
+        round_over, jnp.int32(0), state._raise_count + jnp.int32(action == RAISE)
     )
 
     reward *= jnp.min(chips)
@@ -140,7 +140,7 @@ def _step(state: State, action):
         legal_action_mask=legal_action,
         terminated=terminated,
         rewards=reward,
-        _round=state._round + jnp.int8(round_over),
+        _round=state._round + jnp.int32(round_over),
         _chips=chips,
         _raise_count=raise_count,
     )

--- a/pgx/othello.py
+++ b/pgx/othello.py
@@ -43,7 +43,9 @@ class State(v1.State):
     #  [40, 41, 42, 43, 44, 45, 46, 47],
     #  [48, 49, 50, 51, 52, 53, 54, 55],
     #  [56, 57, 58, 59, 60, 61, 62, 63]]
-    _board: jnp.ndarray = jnp.zeros(64, jnp.int32)  # -1(opp), 0(empty), 1(self)
+    _board: jnp.ndarray = jnp.zeros(
+        64, jnp.int32
+    )  # -1(opp), 0(empty), 1(self)
     _passed: jnp.ndarray = FALSE
 
     @property

--- a/pgx/othello.py
+++ b/pgx/othello.py
@@ -24,7 +24,7 @@ TRUE = jnp.bool_(True)
 
 @dataclass
 class State(v1.State):
-    current_player: jnp.ndarray = jnp.int8(0)
+    current_player: jnp.ndarray = jnp.int32(0)
     observation: jnp.ndarray = jnp.zeros((8, 8, 2), dtype=jnp.bool_)
     rewards: jnp.ndarray = jnp.float32([0.0, 0.0])
     terminated: jnp.ndarray = FALSE
@@ -33,7 +33,7 @@ class State(v1.State):
     _rng_key: jax.random.KeyArray = jax.random.PRNGKey(0)
     _step_count: jnp.ndarray = jnp.int32(0)
     # --- Othello specific ---
-    _turn: jnp.ndarray = jnp.int8(0)
+    _turn: jnp.ndarray = jnp.int32(0)
     # 8x8 board
     # [[ 0,  1,  2,  3,  4,  5,  6,  7],
     #  [ 8,  9, 10, 11, 12, 13, 14, 15],
@@ -43,7 +43,7 @@ class State(v1.State):
     #  [40, 41, 42, 43, 44, 45, 46, 47],
     #  [48, 49, 50, 51, 52, 53, 54, 55],
     #  [56, 57, 58, 59, 60, 61, 62, 63]]
-    _board: jnp.ndarray = jnp.zeros(64, jnp.int8)  # -1(opp), 0(empty), 1(self)
+    _board: jnp.ndarray = jnp.zeros(64, jnp.int32)  # -1(opp), 0(empty), 1(self)
     _passed: jnp.ndarray = FALSE
 
     @property
@@ -104,10 +104,10 @@ SIDE_MASK = LR_MASK & UD_MASK
 
 def _init(rng: jax.random.KeyArray) -> State:
     rng, subkey = jax.random.split(rng)
-    current_player = jnp.int8(jax.random.bernoulli(subkey))
+    current_player = jnp.int32(jax.random.bernoulli(subkey))
     return State(
         current_player=current_player,
-        _board=jnp.zeros(64, dtype=jnp.int8)
+        _board=jnp.zeros(64, dtype=jnp.int32)
         .at[28]
         .set(1)
         .at[35]
@@ -195,7 +195,7 @@ def _step(state, action):
         .set(~legal_action.any()),
         rewards=reward,
         terminated=terminated,
-        _board=-jnp.where(jnp.int8(opp), -1, jnp.int8(my)),
+        _board=-jnp.where(jnp.int32(opp), -1, jnp.int32(my)),
         _passed=action == 64,
     )
 
@@ -234,7 +234,7 @@ def _observe(state, player_id) -> jnp.ndarray:
     def make(color):
         return board * color > 0
 
-    return jnp.stack(jax.vmap(make)(jnp.int8([1, -1])), -1)
+    return jnp.stack(jax.vmap(make)(jnp.int32([1, -1])), -1)
 
 
 def _get_abs_board(state):

--- a/pgx/play2048.py
+++ b/pgx/play2048.py
@@ -26,7 +26,7 @@ ZERO = jnp.int32(0)
 
 @dataclass
 class State(v1.State):
-    current_player: jnp.ndarray = jnp.int8(0)
+    current_player: jnp.ndarray = jnp.int32(0)
     observation: jnp.ndarray = jnp.zeros(16, dtype=jnp.bool_)
     rewards: jnp.ndarray = jnp.float32([0.0])
     terminated: jnp.ndarray = FALSE

--- a/pgx/shogi.py
+++ b/pgx/shogi.py
@@ -38,43 +38,43 @@ MAX_TERMINATION_STEPS = 512  # From AZ paper
 TRUE = jnp.bool_(True)
 FALSE = jnp.bool_(False)
 
-EMPTY = jnp.int8(-1)  # 空白
-PAWN = jnp.int8(0)  # 歩
-LANCE = jnp.int8(1)  # 香
-KNIGHT = jnp.int8(2)  # 桂
-SILVER = jnp.int8(3)  # 銀
-BISHOP = jnp.int8(4)  # 角
-ROOK = jnp.int8(5)  # 飛
-GOLD = jnp.int8(6)  # 金
-KING = jnp.int8(7)  # 玉
-PRO_PAWN = jnp.int8(8)  # と
-PRO_LANCE = jnp.int8(9)  # 成香
-PRO_KNIGHT = jnp.int8(10)  # 成桂
-PRO_SILVER = jnp.int8(11)  # 成銀
-HORSE = jnp.int8(12)  # 馬
-DRAGON = jnp.int8(13)  # 龍
+EMPTY = jnp.int32(-1)  # 空白
+PAWN = jnp.int32(0)  # 歩
+LANCE = jnp.int32(1)  # 香
+KNIGHT = jnp.int32(2)  # 桂
+SILVER = jnp.int32(3)  # 銀
+BISHOP = jnp.int32(4)  # 角
+ROOK = jnp.int32(5)  # 飛
+GOLD = jnp.int32(6)  # 金
+KING = jnp.int32(7)  # 玉
+PRO_PAWN = jnp.int32(8)  # と
+PRO_LANCE = jnp.int32(9)  # 成香
+PRO_KNIGHT = jnp.int32(10)  # 成桂
+PRO_SILVER = jnp.int32(11)  # 成銀
+HORSE = jnp.int32(12)  # 馬
+DRAGON = jnp.int32(13)  # 龍
 # --- opponent pieces ---
-OPP_PAWN = jnp.int8(14)  # 歩
-OPP_LANCE = jnp.int8(15)  # 香
-OPP_KNIGHT = jnp.int8(16)  # 桂
-OPP_SILVER = jnp.int8(17)  # 銀
-OPP_BISHOP = jnp.int8(18)  # 角
-OPP_ROOK = jnp.int8(19)  # 飛
-OPP_GOLD = jnp.int8(20)  # 金
-OPP_KING = jnp.int8(21)  # 玉
-OPP_PRO_PAWN = jnp.int8(22)  # と
-OPP_PRO_LANCE = jnp.int8(23)  # 成香
-OPP_PRO_KNIGHT = jnp.int8(24)  # 成桂
-OPP_PRO_SILVER = jnp.int8(25)  # 成銀
-OPP_HORSE = jnp.int8(26)  # 馬
-OPP_DRAGON = jnp.int8(27)  # 龍
+OPP_PAWN = jnp.int32(14)  # 歩
+OPP_LANCE = jnp.int32(15)  # 香
+OPP_KNIGHT = jnp.int32(16)  # 桂
+OPP_SILVER = jnp.int32(17)  # 銀
+OPP_BISHOP = jnp.int32(18)  # 角
+OPP_ROOK = jnp.int32(19)  # 飛
+OPP_GOLD = jnp.int32(20)  # 金
+OPP_KING = jnp.int32(21)  # 玉
+OPP_PRO_PAWN = jnp.int32(22)  # と
+OPP_PRO_LANCE = jnp.int32(23)  # 成香
+OPP_PRO_KNIGHT = jnp.int32(24)  # 成桂
+OPP_PRO_SILVER = jnp.int32(25)  # 成銀
+OPP_HORSE = jnp.int32(26)  # 馬
+OPP_DRAGON = jnp.int32(27)  # 龍
 
 ALL_SQ = jnp.arange(81)
 
 
 @dataclass
 class State(v1.State):
-    current_player: jnp.ndarray = jnp.int8(0)
+    current_player: jnp.ndarray = jnp.int32(0)
     rewards: jnp.ndarray = jnp.float32([0.0, 0.0])
     terminated: jnp.ndarray = FALSE
     truncated: jnp.ndarray = FALSE
@@ -83,12 +83,12 @@ class State(v1.State):
     _rng_key: jax.random.KeyArray = jax.random.PRNGKey(0)
     _step_count: jnp.ndarray = jnp.int32(0)
     # --- Shogi specific ---
-    _turn: jnp.ndarray = jnp.int8(0)  # 0 or 1
+    _turn: jnp.ndarray = jnp.int32(0)  # 0 or 1
     _board: jnp.ndarray = INIT_PIECE_BOARD  # (81,) flip in turn
-    _hand: jnp.ndarray = jnp.zeros((2, 7), dtype=jnp.int8)  # flip in turn
+    _hand: jnp.ndarray = jnp.zeros((2, 7), dtype=jnp.int32)  # flip in turn
     # cache
     # Redundant information used only in _is_checked for speeding-up
-    _cache_m2b: jnp.ndarray = -jnp.ones(8, dtype=jnp.int8)
+    _cache_m2b: jnp.ndarray = -jnp.ones(8, dtype=jnp.int32)
     _cache_king: jnp.ndarray = jnp.int32(44)
 
     @property
@@ -124,7 +124,7 @@ class Shogi(v1.Env):
     def _init(self, key: jax.random.KeyArray) -> State:
         state = _init_board()
         rng, subkey = jax.random.split(key)
-        current_player = jnp.int8(jax.random.bernoulli(subkey))
+        current_player = jnp.int32(jax.random.bernoulli(subkey))
         return state.replace(current_player=current_player)  # type: ignore
 
     def _step(self, state: v1.State, action: jnp.ndarray) -> State:
@@ -162,7 +162,7 @@ class Action:
     piece: jnp.ndarray
     to: jnp.ndarray
     # --- Optional (only for move action) ---
-    from_: jnp.ndarray = jnp.int8(0)
+    from_: jnp.ndarray = jnp.int32(0)
     is_promotion: jnp.ndarray = FALSE
 
     @staticmethod
@@ -212,7 +212,7 @@ class Action:
         26 Drop 金
         """
         action = jnp.int32(action)
-        direction, to = jnp.int8(action // 81), jnp.int8(action % 81)
+        direction, to = jnp.int32(action // 81), jnp.int32(action % 81)
         is_drop = direction >= 20
         is_promotion = (10 <= direction) & (direction < 20)
         # LEGAL_FROM_IDX[UP, 19] = [20, 21, ... -1]
@@ -529,7 +529,7 @@ def _flip(state):
     pb = pb[::-1]
     return state.replace(  # type: ignore
         _board=pb,
-        _hand=state._hand[jnp.int8((1, 0))],
+        _hand=state._hand[jnp.int32((1, 0))],
     )
 
 
@@ -550,7 +550,7 @@ def _is_major_piece(piece):
 
 def _major_piece_ix(piece):
     ixs = (
-        (-jnp.ones(28, dtype=jnp.int8))
+        (-jnp.ones(28, dtype=jnp.int32))
         .at[LANCE]
         .set(0)
         .at[BISHOP]
@@ -562,7 +562,7 @@ def _major_piece_ix(piece):
         .at[DRAGON]
         .set(2)
     )
-    return jax.lax.select(piece >= 0, ixs[piece], jnp.int8(-1))
+    return jax.lax.select(piece >= 0, ixs[piece], jnp.int32(-1))
 
 
 def _observe(state: State, player_id: jnp.ndarray) -> jnp.ndarray:

--- a/pgx/sparrow_mahjong.py
+++ b/pgx/sparrow_mahjong.py
@@ -57,7 +57,7 @@ MAX_SCORE = (
 
 @dataclass
 class State(v1.State):
-    current_player: jnp.ndarray = jnp.int8(0)
+    current_player: jnp.ndarray = jnp.int32(0)
     observation: jnp.ndarray = jnp.zeros((15, 11), dtype=jnp.bool_)
     rewards: jnp.ndarray = jnp.zeros(3, dtype=jnp.float32)
     terminated: jnp.ndarray = FALSE
@@ -85,7 +85,7 @@ class State(v1.State):
     )  # tile id (0~43) is set
     _draw_ix: jnp.ndarray = jnp.int32(N_PLAYER * 5)
     _shuffled_players: jnp.ndarray = jnp.zeros(
-        N_PLAYER, dtype=jnp.int8
+        N_PLAYER, dtype=jnp.int32
     )  # 0: dealer, ...
     _dora: jnp.ndarray = jnp.int32(0)  # tile type (0~10) is set
     _scores: jnp.ndarray = jnp.zeros(3, dtype=jnp.int32)  # 0 = dealer
@@ -172,7 +172,7 @@ class SparrowMahjong(v1.Env):
 def _init(rng: jax.random.KeyArray):
     # shuffle players and wall
     key1, key2 = jax.random.split(rng)
-    shuffled_players = jnp.arange(N_PLAYER, dtype=jnp.int8)
+    shuffled_players = jnp.arange(N_PLAYER, dtype=jnp.int32)
     shuffled_players = jax.random.permutation(
         key1, shuffled_players, independent=True
     )

--- a/pgx/tic_tac_toe.py
+++ b/pgx/tic_tac_toe.py
@@ -24,7 +24,7 @@ TRUE = jnp.bool_(True)
 
 @dataclass
 class State(v1.State):
-    current_player: jnp.ndarray = jnp.int8(0)
+    current_player: jnp.ndarray = jnp.int32(0)
     observation: jnp.ndarray = jnp.zeros((3, 3, 2), dtype=jnp.bool_)
     rewards: jnp.ndarray = jnp.float32([0.0, 0.0])
     terminated: jnp.ndarray = FALSE
@@ -33,11 +33,11 @@ class State(v1.State):
     _rng_key: jax.random.KeyArray = jax.random.PRNGKey(0)
     _step_count: jnp.ndarray = jnp.int32(0)
     # --- Tic-tac-toe specific ---
-    _turn: jnp.ndarray = jnp.int8(0)
+    _turn: jnp.ndarray = jnp.int32(0)
     # 0 1 2
     # 3 4 5
     # 6 7 8
-    _board: jnp.ndarray = -jnp.ones(9, jnp.int8)  # -1 (empty), 0, 1
+    _board: jnp.ndarray = -jnp.ones(9, jnp.int32)  # -1 (empty), 0, 1
 
     @property
     def env_id(self) -> v1.EnvId:
@@ -74,7 +74,7 @@ class TicTacToe(v1.Env):
 
 def _init(rng: jax.random.KeyArray) -> State:
     rng, subkey = jax.random.split(rng)
-    current_player = jnp.int8(jax.random.bernoulli(subkey))
+    current_player = jnp.int32(jax.random.bernoulli(subkey))
     return State(current_player=current_player)  # type:ignore
 
 
@@ -96,7 +96,7 @@ def _step(state: State, action: jnp.ndarray) -> State:
 
 
 def _win_check(board, turn) -> jnp.ndarray:
-    idx = jnp.int8([[0, 1, 2], [3, 4, 5], [6, 7, 8], [0, 3, 6], [1, 4, 7], [2, 5, 8], [0, 4, 8], [2, 4, 6]])  # type: ignore
+    idx = jnp.int32([[0, 1, 2], [3, 4, 5], [6, 7, 8], [0, 3, 6], [1, 4, 7], [2, 5, 8], [0, 4, 8], [2, 4, 6]])  # type: ignore
     return ((board[idx] == turn).all(axis=1)).any()
 
 
@@ -108,8 +108,8 @@ def _observe(state: State, player_id: jnp.ndarray) -> jnp.ndarray:
     # flip if player_id is opposite
     x = jax.lax.cond(
         state.current_player == player_id,
-        lambda: jnp.int8([state._turn, 1 - state._turn]),
-        lambda: jnp.int8([1 - state._turn, state._turn]),
+        lambda: jnp.int32([state._turn, 1 - state._turn]),
+        lambda: jnp.int32([1 - state._turn, state._turn]),
     )
 
     return jnp.stack(plane(x), -1)

--- a/tests/test_backgammon.py
+++ b/tests/test_backgammon.py
@@ -42,7 +42,7 @@ _exists = jax.jit(_exists)
 
 
 def make_test_boad():
-    board: jnp.ndarray = jnp.zeros(28, dtype=jnp.int8)
+    board: jnp.ndarray = jnp.zeros(28, dtype=jnp.int32)
     # 黒
     board = board.at[19].set(5)
     board = board.at[20].set(1)
@@ -101,7 +101,7 @@ def make_test_state(
 
 def test_flip_board():
     test_board = make_test_boad()
-    board: jnp.ndarray = jnp.zeros(28, dtype=jnp.int8)
+    board: jnp.ndarray = jnp.zeros(28, dtype=jnp.int32)
     board = board.at[4].set(-5)
     board = board.at[3].set(-1)
     board = board.at[2].set(-2)
@@ -135,10 +135,10 @@ def test_is_turn_end():
     # white dance
     board: jnp.ndarray = make_test_boad()
     state = make_test_state(
-        current_player=jnp.int8(1),
+        current_player=jnp.int32(1),
         rng=rng,
         board=board,
-        turn=jnp.int8(1),
+        turn=jnp.int32(1),
         dice=jnp.array([2, 2], dtype=jnp.int16),
         playable_dice=jnp.array([-1, -1, -1, -1], dtype=jnp.int16),
         played_dice_num=jnp.int16(0),
@@ -148,10 +148,10 @@ def test_is_turn_end():
     # No playable dice
     board: jnp.ndarray = make_test_boad()
     state = make_test_state(
-        current_player=jnp.int8(1),
+        current_player=jnp.int32(1),
         rng=rng,
         board=board,
-        turn=jnp.int8(1),
+        turn=jnp.int32(1),
         dice=jnp.array([2, 2], dtype=jnp.int16),
         playable_dice=jnp.array([-1, -1, -1, -1], dtype=jnp.int16),
         played_dice_num=jnp.int16(2),
@@ -166,7 +166,7 @@ def test_change_turn():
     assert state._turn == (_turn + 1) % 2
 
     test_board: jnp.ndarray = make_test_boad()
-    board: jnp.ndarray = jnp.zeros(28, dtype=jnp.int8)
+    board: jnp.ndarray = jnp.zeros(28, dtype=jnp.int32)
     board = board.at[4].set(-5)
     board = board.at[3].set(-1)
     board = board.at[2].set(-2)
@@ -177,17 +177,17 @@ def test_change_turn():
     board = board.at[1].set(3)
     board = board.at[24].set(4)
     state = make_test_state(
-        current_player=jnp.int8(0),
+        current_player=jnp.int32(0),
         rng=rng,
         board=test_board,
-        turn=jnp.int8(0),
+        turn=jnp.int32(0),
         dice=jnp.array([2, 2], dtype=jnp.int16),
         playable_dice=jnp.array([-1, -1, -1, -1], dtype=jnp.int16),
         played_dice_num=jnp.int16(2),
     )
     state = _change_turn(state)
     print(state._board, board)
-    assert state._turn == jnp.int8(1)  # Turn changed
+    assert state._turn == jnp.int32(1)  # Turn changed
     assert (state._board == board).all()  # Flipped.
 
 def test_no_op():
@@ -196,17 +196,17 @@ def test_no_op():
         board, jnp.array([0, 1, -1, -1], dtype=jnp.int16)
     )
     state = make_test_state(
-        current_player=jnp.int8(1),
+        current_player=jnp.int32(1),
         rng=rng,
         board=board,
-        turn=jnp.int8(1),
+        turn=jnp.int32(1),
         dice=jnp.array([0, 1], dtype=jnp.int16),
         playable_dice=jnp.array([0, 1, -1, -1], dtype=jnp.int16),
         played_dice_num=jnp.int16(0),
         legal_action_mask=legal_action_mask,
     )
     state = step(state, 0)  # execute no-op action
-    assert state._turn == jnp.int8(0)  # Turn changes after no-op.
+    assert state._turn == jnp.int32(0)  # Turn changes after no-op.
 
 
 def test_step():
@@ -217,10 +217,10 @@ def test_step():
         board, jnp.array([0, 1, -1, -1], dtype=jnp.int16)
     )
     state = make_test_state(
-        current_player=jnp.int8(1),
+        current_player=jnp.int32(1),
         rng=rng,
         board=board,
-        turn=jnp.int8(1),
+        turn=jnp.int32(1),
         dice=jnp.array([0, 1], dtype=jnp.int16),
         playable_dice=jnp.array([0, 1, -1, -1], dtype=jnp.int16),
         played_dice_num=jnp.int16(0),
@@ -270,10 +270,10 @@ def test_step():
         board, jnp.array([4, 5, -1, -1], dtype=jnp.int16)
     )
     state = make_test_state(
-        current_player=jnp.int8(0),
+        current_player=jnp.int32(0),
         rng=rng,
         board=board,
-        turn=jnp.int8(0),
+        turn=jnp.int32(0),
         dice=jnp.array([4, 5], dtype=jnp.int16),
         playable_dice=jnp.array([4, 5, -1, -1], dtype=jnp.int16),
         played_dice_num=jnp.int16(0),
@@ -301,10 +301,10 @@ def test_observe():
 
     # current_player = white, playable_dice = (1, 2)
     state = make_test_state(
-        current_player=jnp.int8(1),
+        current_player=jnp.int32(1),
         rng=rng,
         board=board,
-        turn=jnp.int8(1),
+        turn=jnp.int32(1),
         dice=jnp.array([0, 1], dtype=jnp.int16),
         playable_dice=jnp.array([0, 1, -1, -1], dtype=jnp.int16),
         played_dice_num=jnp.int16(0),
@@ -312,13 +312,13 @@ def test_observe():
     expected_obs = jnp.concatenate(
         (board, jnp.array([1, 1, 0, 0, 0, 0])), axis=None
     )
-    assert (observe(state, jnp.int8(1)) == expected_obs).all()
+    assert (observe(state, jnp.int32(1)) == expected_obs).all()
 
     state = make_test_state(
-        current_player=jnp.int8(1),
+        current_player=jnp.int32(1),
         rng=rng,
         board=board,
-        turn=jnp.int8(1),
+        turn=jnp.int32(1),
         dice=jnp.array([0, 1], dtype=jnp.int16),
         playable_dice=jnp.array([1, 1, 1, 1], dtype=jnp.int16),
         played_dice_num=jnp.int16(0),
@@ -326,14 +326,14 @@ def test_observe():
     expected_obs = jnp.concatenate(
         (board, jnp.array([0, 4, 0, 0, 0, 0])), axis=None
     )
-    assert (observe(state, jnp.int8(1)) == expected_obs).all()
+    assert (observe(state, jnp.int32(1)) == expected_obs).all()
 
     # current_player = black, playabl_dice = (2)
     state = make_test_state(
-        current_player=jnp.int8(1),
+        current_player=jnp.int32(1),
         rng=rng,
         board=board,
-        turn=jnp.int8(-1),
+        turn=jnp.int32(-1),
         dice=jnp.array([0, 1], dtype=jnp.int16),
         playable_dice=jnp.array([-1, 1, -1, -1], dtype=jnp.int16),
         played_dice_num=jnp.int16(0),
@@ -341,13 +341,13 @@ def test_observe():
     expected_obs = jnp.concatenate(
         (board, jnp.array([0, 1, 0, 0, 0, 0])), axis=None
     )
-    assert (observe(state, jnp.int8(1)) == expected_obs).all()
+    assert (observe(state, jnp.int32(1)) == expected_obs).all()
 
     state = make_test_state(
-        current_player=jnp.int8(1),
+        current_player=jnp.int32(1),
         rng=rng,
         board=board,
-        turn=jnp.int8(-1),
+        turn=jnp.int32(-1),
         dice=jnp.array([0, 1], dtype=jnp.int16),
         playable_dice=jnp.array([-1, 1, -1, -1], dtype=jnp.int16),
         played_dice_num=jnp.int16(0),
@@ -355,7 +355,7 @@ def test_observe():
     expected_obs = jnp.concatenate(
         (1 * board, jnp.array([0, 0, 0, 0, 0, 0])), axis=None
     )
-    assert (observe(state, jnp.int8(0)) == expected_obs).all()
+    assert (observe(state, jnp.int32(0)) == expected_obs).all()
 
 
 def test_is_open():
@@ -397,7 +397,7 @@ def test_is_all_on_home_boad():
 
 def test_rear_distance():
     board = make_test_boad()
-    turn = jnp.int8(-1)
+    turn = jnp.int32(-1)
     # Black
     assert _rear_distance(board) == 5
     # White
@@ -408,7 +408,7 @@ def test_rear_distance():
 def test_distance_to_goal():
     board = make_test_boad()
     # Black
-    turn = jnp.int8(-1)
+    turn = jnp.int32(-1)
     src = 23
     assert _distance_to_goal(src) == 1
     src = 10

--- a/tests/test_backgammon.py
+++ b/tests/test_backgammon.py
@@ -139,9 +139,9 @@ def test_is_turn_end():
         rng=rng,
         board=board,
         turn=jnp.int32(1),
-        dice=jnp.array([2, 2], dtype=jnp.int16),
-        playable_dice=jnp.array([-1, -1, -1, -1], dtype=jnp.int16),
-        played_dice_num=jnp.int16(0),
+        dice=jnp.array([2, 2], dtype=jnp.int32),
+        playable_dice=jnp.array([-1, -1, -1, -1], dtype=jnp.int32),
+        played_dice_num=jnp.int32(0),
     )
     assert _is_turn_end(state)
 
@@ -152,9 +152,9 @@ def test_is_turn_end():
         rng=rng,
         board=board,
         turn=jnp.int32(1),
-        dice=jnp.array([2, 2], dtype=jnp.int16),
-        playable_dice=jnp.array([-1, -1, -1, -1], dtype=jnp.int16),
-        played_dice_num=jnp.int16(2),
+        dice=jnp.array([2, 2], dtype=jnp.int32),
+        playable_dice=jnp.array([-1, -1, -1, -1], dtype=jnp.int32),
+        played_dice_num=jnp.int32(2),
     )
     assert _is_turn_end(state)
 
@@ -181,9 +181,9 @@ def test_change_turn():
         rng=rng,
         board=test_board,
         turn=jnp.int32(0),
-        dice=jnp.array([2, 2], dtype=jnp.int16),
-        playable_dice=jnp.array([-1, -1, -1, -1], dtype=jnp.int16),
-        played_dice_num=jnp.int16(2),
+        dice=jnp.array([2, 2], dtype=jnp.int32),
+        playable_dice=jnp.array([-1, -1, -1, -1], dtype=jnp.int32),
+        played_dice_num=jnp.int32(2),
     )
     state = _change_turn(state)
     print(state._board, board)
@@ -193,16 +193,16 @@ def test_change_turn():
 def test_no_op():
     board: jnp.ndarray = make_test_boad()
     legal_action_mask = _legal_action_mask(
-        board, jnp.array([0, 1, -1, -1], dtype=jnp.int16)
+        board, jnp.array([0, 1, -1, -1], dtype=jnp.int32)
     )
     state = make_test_state(
         current_player=jnp.int32(1),
         rng=rng,
         board=board,
         turn=jnp.int32(1),
-        dice=jnp.array([0, 1], dtype=jnp.int16),
-        playable_dice=jnp.array([0, 1, -1, -1], dtype=jnp.int16),
-        played_dice_num=jnp.int16(0),
+        dice=jnp.array([0, 1], dtype=jnp.int32),
+        playable_dice=jnp.array([0, 1, -1, -1], dtype=jnp.int32),
+        played_dice_num=jnp.int32(0),
         legal_action_mask=legal_action_mask,
     )
     state = step(state, 0)  # execute no-op action
@@ -214,16 +214,16 @@ def test_step():
     board: jnp.ndarray = make_test_boad()
     board = _flip_board(board)  # Flipped
     legal_action_mask = _legal_action_mask(
-        board, jnp.array([0, 1, -1, -1], dtype=jnp.int16)
+        board, jnp.array([0, 1, -1, -1], dtype=jnp.int32)
     )
     state = make_test_state(
         current_player=jnp.int32(1),
         rng=rng,
         board=board,
         turn=jnp.int32(1),
-        dice=jnp.array([0, 1], dtype=jnp.int16),
-        playable_dice=jnp.array([0, 1, -1, -1], dtype=jnp.int16),
-        played_dice_num=jnp.int16(0),
+        dice=jnp.array([0, 1], dtype=jnp.int32),
+        playable_dice=jnp.array([0, 1, -1, -1], dtype=jnp.int32),
+        played_dice_num=jnp.int32(0),
         legal_action_mask=legal_action_mask,
     )
     expected_legal_action_mask: jnp.ndarray = jnp.zeros(
@@ -244,7 +244,7 @@ def test_step():
     # White plays die=2 24(bar)->1
     state = step(state=state, action=(1) * 6 + 1)
     assert (
-            state._playable_dice == jnp.array([0, -1, -1, -1], dtype=jnp.int16)
+            state._playable_dice == jnp.array([0, -1, -1, -1], dtype=jnp.int32)
     ).all()  # Is playable dice updated correctly?
     assert state._played_dice_num == 1  # played dice increased?
     assert state._turn == 1  # turn is not changed?
@@ -267,16 +267,16 @@ def test_step():
     # black
     board: jnp.ndarray = make_test_boad()
     legal_action_mask = _legal_action_mask(
-        board, jnp.array([4, 5, -1, -1], dtype=jnp.int16)
+        board, jnp.array([4, 5, -1, -1], dtype=jnp.int32)
     )
     state = make_test_state(
         current_player=jnp.int32(0),
         rng=rng,
         board=board,
         turn=jnp.int32(0),
-        dice=jnp.array([4, 5], dtype=jnp.int16),
-        playable_dice=jnp.array([4, 5, -1, -1], dtype=jnp.int16),
-        played_dice_num=jnp.int16(0),
+        dice=jnp.array([4, 5], dtype=jnp.int32),
+        playable_dice=jnp.array([4, 5, -1, -1], dtype=jnp.int32),
+        played_dice_num=jnp.int32(0),
         legal_action_mask=legal_action_mask,
     )
     expected_legal_action_mask: jnp.ndarray = jnp.zeros(
@@ -305,9 +305,9 @@ def test_observe():
         rng=rng,
         board=board,
         turn=jnp.int32(1),
-        dice=jnp.array([0, 1], dtype=jnp.int16),
-        playable_dice=jnp.array([0, 1, -1, -1], dtype=jnp.int16),
-        played_dice_num=jnp.int16(0),
+        dice=jnp.array([0, 1], dtype=jnp.int32),
+        playable_dice=jnp.array([0, 1, -1, -1], dtype=jnp.int32),
+        played_dice_num=jnp.int32(0),
     )
     expected_obs = jnp.concatenate(
         (board, jnp.array([1, 1, 0, 0, 0, 0])), axis=None
@@ -319,9 +319,9 @@ def test_observe():
         rng=rng,
         board=board,
         turn=jnp.int32(1),
-        dice=jnp.array([0, 1], dtype=jnp.int16),
-        playable_dice=jnp.array([1, 1, 1, 1], dtype=jnp.int16),
-        played_dice_num=jnp.int16(0),
+        dice=jnp.array([0, 1], dtype=jnp.int32),
+        playable_dice=jnp.array([1, 1, 1, 1], dtype=jnp.int32),
+        played_dice_num=jnp.int32(0),
     )
     expected_obs = jnp.concatenate(
         (board, jnp.array([0, 4, 0, 0, 0, 0])), axis=None
@@ -334,9 +334,9 @@ def test_observe():
         rng=rng,
         board=board,
         turn=jnp.int32(-1),
-        dice=jnp.array([0, 1], dtype=jnp.int16),
-        playable_dice=jnp.array([-1, 1, -1, -1], dtype=jnp.int16),
-        played_dice_num=jnp.int16(0),
+        dice=jnp.array([0, 1], dtype=jnp.int32),
+        playable_dice=jnp.array([-1, 1, -1, -1], dtype=jnp.int32),
+        played_dice_num=jnp.int32(0),
     )
     expected_obs = jnp.concatenate(
         (board, jnp.array([0, 1, 0, 0, 0, 0])), axis=None
@@ -348,9 +348,9 @@ def test_observe():
         rng=rng,
         board=board,
         turn=jnp.int32(-1),
-        dice=jnp.array([0, 1], dtype=jnp.int16),
-        playable_dice=jnp.array([-1, 1, -1, -1], dtype=jnp.int16),
-        played_dice_num=jnp.int16(0),
+        dice=jnp.array([0, 1], dtype=jnp.int32),
+        playable_dice=jnp.array([-1, 1, -1, -1], dtype=jnp.int32),
+        played_dice_num=jnp.int32(0),
     )
     expected_obs = jnp.concatenate(
         (1 * board, jnp.array([0, 0, 0, 0, 0, 0])), axis=None
@@ -492,7 +492,7 @@ def test_move():
 def test_legal_action():
     board = make_test_boad()
     # black
-    playable_dice = jnp.array([3, 2, -1, -1], dtype=jnp.int16)
+    playable_dice = jnp.array([3, 2, -1, -1], dtype=jnp.int32)
     expected_legal_action_mask: jnp.ndarray = jnp.zeros(
         6 * 26, dtype=jnp.bool_
     )
@@ -521,7 +521,7 @@ def test_legal_action():
     print(jnp.where(expected_legal_action_mask != 0)[0])
     assert (expected_legal_action_mask == legal_action_mask).all()
 
-    playable_dice = jnp.array([5, 5, 5, 5], dtype=jnp.int16)
+    playable_dice = jnp.array([5, 5, 5, 5], dtype=jnp.int32)
     expected_legal_action_mask = jnp.zeros(6 * 26, dtype=jnp.bool_)
     expected_legal_action_mask = expected_legal_action_mask.at[
         6 * (19 + 2) + 5
@@ -531,7 +531,7 @@ def test_legal_action():
 
     # white
     board = _flip_board(board)
-    playable_dice = jnp.array([4, 1, -1, -1], dtype=jnp.int16)
+    playable_dice = jnp.array([4, 1, -1, -1], dtype=jnp.int32)
     expected_legal_action_mask: jnp.ndarray = jnp.zeros(
         6 * 26, dtype=jnp.bool_
     )
@@ -541,7 +541,7 @@ def test_legal_action():
     legal_action_mask = _legal_action_mask(board, playable_dice)
     assert (expected_legal_action_mask == legal_action_mask).all()
 
-    playable_dice = jnp.array([4, 4, 4, 4], dtype=jnp.int16)
+    playable_dice = jnp.array([4, 4, 4, 4], dtype=jnp.int32)
     expected_legal_action_mask = jnp.zeros(
         6 * 26, dtype=jnp.bool_
     )  # dance
@@ -554,20 +554,20 @@ def test_legal_action():
 
 def test_calc_win_score():
     # backgammon win by black
-    back_gammon_board = jnp.zeros(28, dtype=jnp.int16)
+    back_gammon_board = jnp.zeros(28, dtype=jnp.int32)
     back_gammon_board = back_gammon_board.at[26].set(15)
     back_gammon_board = back_gammon_board.at[23].set(-15)  # black on home board
     print(_calc_win_score(back_gammon_board))
     assert _calc_win_score(back_gammon_board) == 3
 
     # gammon win by black
-    gammon_board = jnp.zeros(28, dtype=jnp.int16)
+    gammon_board = jnp.zeros(28, dtype=jnp.int32)
     gammon_board = gammon_board.at[26].set(15)
     gammon_board = gammon_board.at[7].set(-15)
     assert _calc_win_score(gammon_board) == 2
 
     # single win by black
-    single_board = jnp.zeros(28, dtype=jnp.int16)
+    single_board = jnp.zeros(28, dtype=jnp.int32)
     single_board = single_board.at[26].set(15)
     single_board = single_board.at[27].set(-3)
     single_board = single_board.at[3].set(-12)
@@ -575,7 +575,7 @@ def test_calc_win_score():
 
 
 def test_black_off():
-    board: jnp.ndarray = jnp.zeros(28, dtype=jnp.int16)
+    board: jnp.ndarray = jnp.zeros(28, dtype=jnp.int32)
     board = board.at[0].set(15)
     playable_dice = jnp.array([3, 2, -1, -1])
     legal_action_mask = _legal_action_mask(board, playable_dice)

--- a/tests/test_bridge_bidding.py
+++ b/tests/test_bridge_bidding.py
@@ -31,7 +31,7 @@ def init(rng: jax.random.KeyArray) -> State:
     hand = jax.random.permutation(rng2, hand)
     vul_NS = jax.random.choice(rng3, jnp.bool_([False, True]))
     vul_EW = jax.random.choice(rng4, jnp.bool_([False, True]))
-    dealer = jax.random.randint(rng5, (1,), 0, 4, dtype=jnp.int8)[0]
+    dealer = jax.random.randint(rng5, (1,), 0, 4, dtype=jnp.int32)[0]
     # shuffled players and arrange in order of NESW
     shuffled_players = _shuffle_players(rng6)
     current_player = shuffled_players[dealer]
@@ -134,18 +134,18 @@ def test_step():
     state = _init_by_key(HASH_TABLE_SAMPLE_KEYS[0], key)
     # state = init_by_key(HASH_TABLE_SAMPLE_KEYS[0], key)
     state = state.replace(
-        _dealer=jnp.int8(1),
-        current_player=jnp.int8(3),
-        _shuffled_players=jnp.array([0, 3, 1, 2], dtype=jnp.int8),
+        _dealer=jnp.int32(1),
+        current_player=jnp.int32(3),
+        _shuffled_players=jnp.array([0, 3, 1, 2], dtype=jnp.int32),
         _vul_NS=jnp.bool_(0),
         _vul_EW=jnp.bool_(0),
     )
-    bidding_history = jnp.full(319, -1, dtype=jnp.int8)
+    bidding_history = jnp.full(319, -1, dtype=jnp.int32)
     legal_action_mask = jnp.ones(38, dtype=jnp.bool_)
     legal_action_mask = legal_action_mask.at[DOUBLE_ACTION_NUM].set(False)
     legal_action_mask = legal_action_mask.at[REDOUBLE_ACTION_NUM].set(False)
-    first_denomination_NS = jnp.full(5, -1, dtype=jnp.int8)
-    first_denomination_EW = jnp.full(5, -1, dtype=jnp.int8)
+    first_denomination_NS = jnp.full(5, -1, dtype=jnp.int32)
+    first_denomination_EW = jnp.full(5, -1, dtype=jnp.int32)
 
     action = next(actions)
     state = step(state, action)
@@ -1008,19 +1008,19 @@ def test_pass_out():
     state = _init_by_key(HASH_TABLE_SAMPLE_KEYS[0], key)
     # state = init_by_key(HASH_TABLE_SAMPLE_KEYS[1], key)
     state = state.replace(
-        _dealer=jnp.int8(1),
-        current_player=jnp.int8(3),
-        _shuffled_players=jnp.array([0, 3, 1, 2], dtype=jnp.int8),
+        _dealer=jnp.int32(1),
+        current_player=jnp.int32(3),
+        _shuffled_players=jnp.array([0, 3, 1, 2], dtype=jnp.int32),
         _vul_NS=jnp.bool_(0),
         _vul_EW=jnp.bool_(0),
     )
 
-    bidding_history = jnp.full(319, -1, dtype=jnp.int8)
+    bidding_history = jnp.full(319, -1, dtype=jnp.int32)
     legal_action_mask = jnp.ones(38, dtype=jnp.bool_)
     legal_action_mask = legal_action_mask.at[DOUBLE_ACTION_NUM].set(False)
     legal_action_mask = legal_action_mask.at[REDOUBLE_ACTION_NUM].set(False)
-    first_denomination_NS = jnp.full(5, -1, dtype=jnp.int8)
-    first_denomination_EW = jnp.full(5, -1, dtype=jnp.int8)
+    first_denomination_NS = jnp.full(5, -1, dtype=jnp.int32)
+    first_denomination_EW = jnp.full(5, -1, dtype=jnp.int32)
 
     action = next(actions)
     state = step(state, action)
@@ -1148,9 +1148,9 @@ def test_observe():
     HASH_TABLE_SAMPLE_KEYS, HASH_TABLE_SAMPLE_VALUES = _load_sample_hash()
     state = _init_by_key(HASH_TABLE_SAMPLE_KEYS[0], key)
     state = state.replace(
-        _dealer=jnp.int8(1),
-        current_player=jnp.int8(3),
-        _shuffled_players=jnp.array([0, 3, 1, 2], dtype=jnp.int8),
+        _dealer=jnp.int32(1),
+        current_player=jnp.int32(3),
+        _shuffled_players=jnp.array([0, 3, 1, 2], dtype=jnp.int32),
         _vul_NS=jnp.bool_(0),
         _vul_EW=jnp.bool_(0),
     )
@@ -1179,9 +1179,9 @@ def test_observe():
     # dealer team: EW
     # non dealer team: NS
     state = state.replace(
-        _dealer=jnp.int8(1),
-        current_player=jnp.int8(3),
-        _shuffled_players=jnp.array([0, 3, 1, 2], dtype=jnp.int8),
+        _dealer=jnp.int32(1),
+        current_player=jnp.int32(3),
+        _shuffled_players=jnp.array([0, 3, 1, 2], dtype=jnp.int32),
         _vul_NS=jnp.bool_(1),
         _vul_EW=jnp.bool_(0),
     )
@@ -1196,9 +1196,9 @@ def test_observe():
     assert jnp.all(obs == init_obs)
 
     state = state.replace(
-        _dealer=jnp.int8(1),
-        current_player=jnp.int8(3),
-        _shuffled_players=jnp.array([0, 3, 1, 2], dtype=jnp.int8),
+        _dealer=jnp.int32(1),
+        current_player=jnp.int32(3),
+        _shuffled_players=jnp.array([0, 3, 1, 2], dtype=jnp.int32),
         _vul_NS=jnp.bool_(0),
         _vul_EW=jnp.bool_(1),
     )
@@ -1214,9 +1214,9 @@ def test_observe():
     assert jnp.all(obs == init_obs)
 
     state = state.replace(
-        _dealer=jnp.int8(1),
-        current_player=jnp.int8(3),
-        _shuffled_players=jnp.array([0, 3, 1, 2], dtype=jnp.int8),
+        _dealer=jnp.int32(1),
+        current_player=jnp.int32(3),
+        _shuffled_players=jnp.array([0, 3, 1, 2], dtype=jnp.int32),
         _vul_NS=jnp.bool_(1),
         _vul_EW=jnp.bool_(1),
     )
@@ -1255,9 +1255,9 @@ def test_observe():
     history = jnp.zeros(424, dtype=jnp.bool_)
 
     state = state.replace(
-        _dealer=jnp.int8(1),
-        current_player=jnp.int8(3),
-        _shuffled_players=jnp.array([0, 3, 1, 2], dtype=jnp.int8),
+        _dealer=jnp.int32(1),
+        current_player=jnp.int32(3),
+        _shuffled_players=jnp.array([0, 3, 1, 2], dtype=jnp.int32),
         _vul_NS=jnp.bool_(0),
         _vul_EW=jnp.bool_(0),
     )
@@ -2045,7 +2045,7 @@ def test_calc_score():
 
 
 def test_to_binary():
-    x = jnp.arange(52, dtype=jnp.int8)[::-1].reshape((4, 13)) % 4
+    x = jnp.arange(52, dtype=jnp.int32)[::-1].reshape((4, 13)) % 4
     y = _to_binary(x)
 
     assert jnp.all(
@@ -2053,13 +2053,13 @@ def test_to_binary():
         == jnp.array([60003219, 38686286, 20527417, 15000804], dtype=jnp.int32)
     )
 
-    x = jnp.arange(52, dtype=jnp.int8).reshape((4, 13)) // 13
+    x = jnp.arange(52, dtype=jnp.int32).reshape((4, 13)) // 13
     y = _to_binary(x)
     assert jnp.all(
         y == jnp.array([0, 22369621, 44739242, 67108863], dtype=jnp.int32)
     )
 
-    x = jnp.arange(52, dtype=jnp.int8)[::-1].reshape((4, 13)) // 13
+    x = jnp.arange(52, dtype=jnp.int32)[::-1].reshape((4, 13)) // 13
     y = _to_binary(x)
     assert jnp.all(
         y == jnp.array([67108863, 44739242, 22369621, 0], dtype=jnp.int32)
@@ -2069,14 +2069,14 @@ def test_to_binary():
 def test_state_to_pbn():
     key = jax.random.PRNGKey(0)
     state = init(key)
-    state = state.replace(_hand=jnp.arange(52, dtype=jnp.int8))
+    state = state.replace(_hand=jnp.arange(52, dtype=jnp.int32))
     pbn = _state_to_pbn(state)
     assert (
         pbn
         == "N:AKQJT98765432... .AKQJT98765432.. ..AKQJT98765432. ...AKQJT98765432"
     )
 
-    state = state.replace(_hand=jnp.arange(52, dtype=jnp.int8)[::-1])
+    state = state.replace(_hand=jnp.arange(52, dtype=jnp.int32)[::-1])
     pbn = _state_to_pbn(state)
     assert (
         pbn
@@ -2104,13 +2104,13 @@ def test_state_to_key():
     rng = jax.random.PRNGKey(0)
     state = init(rng)
 
-    state = state.replace(_hand=jnp.arange(52, dtype=jnp.int8))
+    state = state.replace(_hand=jnp.arange(52, dtype=jnp.int32))
     key = _state_to_key(state)
     assert jnp.all(
         key == jnp.array([0, 22369621, 44739242, 67108863], dtype=jnp.int32)
     )
 
-    state = state.replace(_hand=jnp.arange(52, dtype=jnp.int8)[::-1])
+    state = state.replace(_hand=jnp.arange(52, dtype=jnp.int32)[::-1])
     key = _state_to_key(state)
     assert jnp.all(
         key == jnp.array([67108863, 44739242, 22369621, 0], dtype=jnp.int32)
@@ -2136,11 +2136,11 @@ def test_state_to_key():
 def test_key_to_hand():
     key = jnp.array([0, 22369621, 44739242, 67108863], dtype=jnp.int32)
     hand = _key_to_hand(key)
-    assert jnp.all(hand == jnp.arange(52, dtype=jnp.int8))
+    assert jnp.all(hand == jnp.arange(52, dtype=jnp.int32))
 
     key = jnp.array([67108863, 44739242, 22369621, 0], dtype=jnp.int32)
     hand = _key_to_hand(key)
-    correct_hand = jnp.arange(52, dtype=jnp.int8)[::-1]
+    correct_hand = jnp.arange(52, dtype=jnp.int32)[::-1]
     sorted_correct_hand = jnp.concatenate(
         [
             jnp.sort(correct_hand[:13]),
@@ -2199,7 +2199,7 @@ def test_calcurate_dds_tricks():
     with open("tests/assets/contractbridge-ddstable-sample100.csv", "r") as f:
         reader = csv.reader(f, delimiter=",")
         for i in reader:
-            samples.append([i[0], np.array(i[1:]).astype(np.int8)])
+            samples.append([i[0], np.array(i[1:]).astype(np.int32)])
     key = jax.random.PRNGKey(0)
     for i in range(len(HASH_TABLE_SAMPLE_KEYS)):
         key, subkey = jax.random.split(key)
@@ -2221,7 +2221,7 @@ def test_value_to_dds_tricks():
         == jnp.array(
             [ 0,  1,  0,  4,  0, 13, 12, 13,  9, 13,  0,  1,  0,  4,  0, 13, 12,
            13,  9, 13],
-            dtype=jnp.int8,
+            dtype=jnp.int32,
         )
     )
     # fmt: on
@@ -2240,7 +2240,7 @@ def to_value(sample: list) -> jnp.ndarray:
     >>> to_value(sample)
     Array([  4160, 904605,   4160, 904605], dtype=int32)
     """
-    jnp_sample = jnp.array([int(s) for s in sample], dtype=np.int8).reshape(
+    jnp_sample = jnp.array([int(s) for s in sample], dtype=np.int32).reshape(
         4, 5
     )
     return to_binary(jnp_sample)

--- a/tests/test_bridge_bidding.py
+++ b/tests/test_bridge_bidding.py
@@ -932,7 +932,7 @@ def test_step():
     assert state._pass_num == 3
     assert state.rewards.shape == (4,)
     assert jnp.all(
-        state.rewards == jnp.array([-600, -600, 600, 600], dtype=jnp.int16)
+        state.rewards == jnp.array([-600, -600, 600, 600], dtype=jnp.int32)
     )
     declare_position, denomination, level, vul = _contract(state)
     assert declare_position == 0
@@ -2006,12 +2006,12 @@ def test_calc_score():
                                 ]
 
                             actural_score = _calc_score(
-                                jnp.int16(denomination),
-                                jnp.int16(level),
-                                jnp.int16(vul),
-                                jnp.int16(call_x),
-                                jnp.int16(call_xx),
-                                jnp.int16(trick),
+                                jnp.int32(denomination),
+                                jnp.int32(level),
+                                jnp.int32(vul),
+                                jnp.int32(call_x),
+                                jnp.int32(call_xx),
+                                jnp.int32(trick),
                             )
                             assert actural_score == expected_score
                             assert actural_score.shape == ()

--- a/tests/test_go.py
+++ b/tests/test_go.py
@@ -360,7 +360,7 @@ def test_observe():
     # + + + + +
     # + + + + +
     # fmt: off
-    curr_board = jnp.int8(
+    curr_board = jnp.int32(
         [[ 0, -1,  0, -1, 1],
          [-1,  1, -1,  0, 0],
          [ 0,  0,  0,  0, 0],

--- a/tests/test_hex.py
+++ b/tests/test_hex.py
@@ -26,7 +26,7 @@ def test_merge():
     state = step(state, 2)
     state = step(state, 22)
     # fmt: off
-    expected = jnp.int16([
+    expected = jnp.int32([
           3,   3,   3,   3,   0,   0,   0,   0,   0,   0,   0,
         -23, -23, -23,   0,   0,   0,   0,   0,   0,   0,   0,
         -23,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
@@ -164,12 +164,12 @@ def test_random_play():
     done = jnp.bool_(False)
     key, sub_key = jax.random.split(key)
     state = init(sub_key)
-    rewards = jnp.int16([0.0, 0.0])
+    rewards = jnp.int32([0.0, 0.0])
     while not done:
         legal_actions = jnp.where(state.legal_action_mask)[0]
         key, sub_key = jax.random.split(key)
         action = jax.random.choice(sub_key, legal_actions)
-        state = step(state, jnp.int16(action))
+        state = step(state, jnp.int32(action))
         done = state.terminated
         rewards += state.rewards
 

--- a/tests/test_othello.py
+++ b/tests/test_othello.py
@@ -120,12 +120,12 @@ def test_random_play():
     done = jnp.bool_(False)
     key, sub_key = jax.random.split(key)
     state = init(sub_key)
-    rewards = jnp.int16([0.0, 0.0])
+    rewards = jnp.int32([0.0, 0.0])
     while not done:
         legal_actions = jnp.where(state.legal_action_mask)[0]
         key, sub_key = jax.random.split(key)
         action = jax.random.choice(sub_key, legal_actions)
-        state = step(state, jnp.int16(action))
+        state = step(state, jnp.int32(action))
         done = state.terminated
         rewards += state.rewards
 

--- a/tests/test_othello.py
+++ b/tests/test_othello.py
@@ -25,7 +25,7 @@ def test_step():
     state = step(state, 34)
     state = step(state, 17)
     # fmt: off
-    expected = jnp.int8([
+    expected = jnp.int32([
         0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0,
         0, -1, -1, -1, -1, -1, 0, 0,

--- a/tests/test_play2048.py
+++ b/tests/test_play2048.py
@@ -125,7 +125,7 @@ def test_random_play():
             legal_actions = jnp.where(state.legal_action_mask)[0]
             key, sub_key = jax.random.split(key)
             action = jax.random.choice(sub_key, legal_actions)
-            state = step(state, jnp.int16(action))
+            state = step(state, jnp.int32(action))
             assert (state.rewards >= 0).all()
             done = state.terminated
 

--- a/tests/test_sparrow_mahjong.py
+++ b/tests/test_sparrow_mahjong.py
@@ -499,7 +499,7 @@ def test_observe():
     state = _init(jax.random.PRNGKey(1))
     state = step(state, jnp.int32(1))
     print(_to_str(state))
-    obs = observe(state, player_id=jnp.int8(2))
+    obs = observe(state, player_id=jnp.int32(2))
     assert obs.shape[0] == 11
     assert obs.shape[1] == 15
     assert jnp.all(obs[:, 0] == jnp.bool_([0, 0, 1, 0, 1, 0, 0, 1, 0, 1, 0]))
@@ -528,7 +528,7 @@ def test_observe():
      [2] 4 6*8 9*9   : 3 3 _ _ _ _ _ _ _ _  
      [1] 1 2*3 4 5   : r*_ _ _ _ _ _ _ _ _  
     """
-    obs = observe(state, player_id=jnp.int8(0))
+    obs = observe(state, player_id=jnp.int32(0))
     assert obs.shape[0] == 11
     assert obs.shape[1] == 15
     assert jnp.all(obs[:, 0] == jnp.bool_([1, 0, 0, 1, 1, 1, 0, 1, 0, 0, 0]))
@@ -546,7 +546,7 @@ def test_observe():
     assert jnp.all(obs[:, 12] == jnp.bool_([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]))
     assert jnp.all(obs[:, 13] == jnp.bool_([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]))
     assert jnp.all(obs[:, 14] == jnp.bool_([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]))
-    obs = observe(state, player_id=jnp.int8(1))
+    obs = observe(state, player_id=jnp.int32(1))
     assert obs.shape[0] == 11
     assert obs.shape[1] == 15
     assert jnp.all(obs[:, 0] == jnp.bool_([1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0]))
@@ -564,7 +564,7 @@ def test_observe():
     assert jnp.all(obs[:, 12] == jnp.bool_([0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0]))
     assert jnp.all(obs[:, 13] == jnp.bool_([0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0]))
     assert jnp.all(obs[:, 14] == jnp.bool_([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]))
-    obs = observe(state, player_id=jnp.int8(2))
+    obs = observe(state, player_id=jnp.int32(2))
     assert obs.shape[0] == 11
     assert obs.shape[1] == 15
     assert jnp.all(obs[:, 0] == jnp.bool_([0, 0, 0, 1, 0, 1, 0, 1, 1, 0, 0]))

--- a/tests/test_tic_tac_toe.py
+++ b/tests/test_tic_tac_toe.py
@@ -103,7 +103,7 @@ def test_step():
         == jnp.array([1, 1, 1, 1, 1, 1, 1, 1, 1], jnp.bool_)
     )  # fmt: ignore
     assert jnp.all(state._board == jnp.int32([1, 0, -1, -1, 0, -1, -1, 0, 1]))
-    assert jnp.all(state.rewards == jnp.int16([-1, 1]))  # fmt: ignore
+    assert jnp.all(state.rewards == jnp.int32([-1, 1]))  # fmt: ignore
     assert state.terminated
     #  1  0 -1
     # -1  0 -1
@@ -117,7 +117,7 @@ def test_random_play():
         done = jnp.bool_(False)
         key, sub_key = jax.random.split(key)
         state = init(sub_key)
-        rewards = jnp.int16([0.0, 0.0])
+        rewards = jnp.int32([0.0, 0.0])
         while not done:
             assert jnp.all(rewards == 0), state._board
             legal_actions = jnp.where(state.legal_action_mask)[0]

--- a/tests/test_tic_tac_toe.py
+++ b/tests/test_tic_tac_toe.py
@@ -25,14 +25,14 @@ def test_step():
         == jnp.array([1, 1, 1, 1, 1, 1, 1, 1, 1], jnp.bool_)
     )  # fmt: ignore
     assert jnp.all(
-        state._board == jnp.int8([-1, -1, -1, -1, -1, -1, -1, -1, -1])
+        state._board == jnp.int32([-1, -1, -1, -1, -1, -1, -1, -1, -1])
     )
     assert not state.terminated
     # -1 -1 -1
     # -1 -1 -1
     # -1 -1 -1
 
-    action = jnp.int8(4)
+    action = jnp.int32(4)
     state = step(state, action)
     assert state.current_player == 0
     assert state._turn == 1
@@ -41,7 +41,7 @@ def test_step():
         == jnp.array([1, 1, 1, 1, 0, 1, 1, 1, 1], jnp.bool_)
     )  # fmt: ignore
     assert jnp.all(
-        state._board == jnp.int8([-1, -1, -1, -1, 0, -1, -1, -1, -1])
+        state._board == jnp.int32([-1, -1, -1, -1, 0, -1, -1, -1, -1])
     )
     assert jnp.all(state.rewards == 0)  # fmt: ignore
     assert not state.terminated
@@ -49,7 +49,7 @@ def test_step():
     # -1  0 -1
     # -1 -1 -1
 
-    action = jnp.int8(0)
+    action = jnp.int32(0)
     state = step(state, action)
     assert state.current_player == 1
     assert state._turn == 0
@@ -57,14 +57,14 @@ def test_step():
         state.legal_action_mask
         == jnp.array([0, 1, 1, 1, 0, 1, 1, 1, 1], jnp.bool_)
     )  # fmt: ignore
-    assert jnp.all(state._board == jnp.int8([1, -1, -1, -1, 0, -1, -1, -1, -1]))
+    assert jnp.all(state._board == jnp.int32([1, -1, -1, -1, 0, -1, -1, -1, -1]))
     assert jnp.all(state.rewards == 0)  # fmt: ignore
     assert not state.terminated
     #  1 -1 -1
     # -1  0 -1
     # -1 -1 -1
 
-    action = jnp.int8(1)
+    action = jnp.int32(1)
     state = step(state, action)
     assert state.current_player == 0
     assert state._turn == 1
@@ -72,14 +72,14 @@ def test_step():
         state.legal_action_mask
         == jnp.array([0, 0, 1, 1, 0, 1, 1, 1, 1], jnp.bool_)
     )  # fmt: ignore
-    assert jnp.all(state._board == jnp.int8([1, 0, -1, -1, 0, -1, -1, -1, -1]))
+    assert jnp.all(state._board == jnp.int32([1, 0, -1, -1, 0, -1, -1, -1, -1]))
     assert jnp.all(state.rewards == 0)  # fmt: ignore
     assert not state.terminated
     #  1  0 -1
     # -1  0 -1
     # -1 -1 -1
 
-    action = jnp.int8(8)
+    action = jnp.int32(8)
     state = step(state, action)
     assert state.current_player == 1
     assert state._turn == 0
@@ -87,14 +87,14 @@ def test_step():
         state.legal_action_mask
         == jnp.array([0, 0, 1, 1, 0, 1, 1, 1, 0], jnp.bool_)
     )  # fmt: ignore
-    assert jnp.all(state._board == jnp.int8([1, 0, -1, -1, 0, -1, -1, -1, 1]))
+    assert jnp.all(state._board == jnp.int32([1, 0, -1, -1, 0, -1, -1, -1, 1]))
     assert jnp.all(state.rewards == 0)  # fmt: ignore
     assert not state.terminated
     #  1  0 -1
     # -1  0 -1
     # -1 -1  1
 
-    action = jnp.int8(7)
+    action = jnp.int32(7)
     state = step(state, action)
     assert state.current_player == 0
     assert state._turn == 1
@@ -102,7 +102,7 @@ def test_step():
         state.legal_action_mask
         == jnp.array([1, 1, 1, 1, 1, 1, 1, 1, 1], jnp.bool_)
     )  # fmt: ignore
-    assert jnp.all(state._board == jnp.int8([1, 0, -1, -1, 0, -1, -1, 0, 1]))
+    assert jnp.all(state._board == jnp.int32([1, 0, -1, -1, 0, -1, -1, 0, 1]))
     assert jnp.all(state.rewards == jnp.int16([-1, 1]))  # fmt: ignore
     assert state.terminated
     #  1  0 -1
@@ -129,48 +129,48 @@ def test_random_play():
 
 
 def test_win_check():
-    board = jnp.int8([-1, -1, -1, -1, -1, -1, -1, -1, -1])
-    turn = jnp.int8(1)
+    board = jnp.int32([-1, -1, -1, -1, -1, -1, -1, -1, -1])
+    turn = jnp.int32(1)
     assert not _win_check(board, turn)
 
-    board = jnp.int8([1, -1, -1, -1, 1, -1, 0, -1, 0])
-    turn = jnp.int8(1)
+    board = jnp.int32([1, -1, -1, -1, 1, -1, 0, -1, 0])
+    turn = jnp.int32(1)
     assert not _win_check(board, turn)
 
-    board = jnp.int8([1, -1, -1, -1, 1, -1, -1, -1, 1])
-    turn = jnp.int8(1)
+    board = jnp.int32([1, -1, -1, -1, 1, -1, -1, -1, 1])
+    turn = jnp.int32(1)
     assert _win_check(board, turn)
 
-    board = jnp.int8([-1, -1, 1, -1, 1, -1, 1, -1, -1])
-    turn = jnp.int8(1)
+    board = jnp.int32([-1, -1, 1, -1, 1, -1, 1, -1, -1])
+    turn = jnp.int32(1)
     assert _win_check(board, turn)
 
-    board = jnp.int8([1, 1, 1, -1, -1, -1, -1, -1, -1])
-    turn = jnp.int8(1)
+    board = jnp.int32([1, 1, 1, -1, -1, -1, -1, -1, -1])
+    turn = jnp.int32(1)
     assert _win_check(board, turn)
 
-    board = jnp.int8([-1, -1, -1, 1, 1, 1, -1, -1, -1])
-    turn = jnp.int8(1)
+    board = jnp.int32([-1, -1, -1, 1, 1, 1, -1, -1, -1])
+    turn = jnp.int32(1)
     assert _win_check(board, turn)
 
-    board = jnp.int8([-1, -1, -1, -1, -1, -1, 1, 1, 1])
-    turn = jnp.int8(1)
+    board = jnp.int32([-1, -1, -1, -1, -1, -1, 1, 1, 1])
+    turn = jnp.int32(1)
     assert _win_check(board, turn)
 
-    board = jnp.int8([1, -1, -1, 1, -1, -1, 1, -1, -1])
-    turn = jnp.int8(1)
+    board = jnp.int32([1, -1, -1, 1, -1, -1, 1, -1, -1])
+    turn = jnp.int32(1)
     assert _win_check(board, turn)
 
-    board = jnp.int8([-1, 1, -1, -1, 1, -1, -1, 1, -1])
-    turn = jnp.int8(1)
+    board = jnp.int32([-1, 1, -1, -1, 1, -1, -1, 1, -1])
+    turn = jnp.int32(1)
     assert _win_check(board, turn)
 
-    board = jnp.int8([-1, -1, 1, -1, -1, 1, -1, -1, 1])
-    turn = jnp.int8(1)
+    board = jnp.int32([-1, -1, 1, -1, -1, 1, -1, -1, 1])
+    turn = jnp.int32(1)
     assert _win_check(board, turn)
 
-    board = jnp.int8([-1, 0, -1, -1, 0, -1, -1, 0, -1])
-    turn = jnp.int8(0)
+    board = jnp.int32([-1, 0, -1, -1, 0, -1, -1, 0, -1])
+    turn = jnp.int32(0)
     assert _win_check(board, turn)
 
 


### PR DESCRIPTION
Found some buggy behaviors in `int8` (e.g., failed to indexing via `int8` var)