### PR TITLE
[Go] Fix `size` attribute jittable

### DIFF
--- a/pgx/_src/api_test.py
+++ b/pgx/_src/api_test.py
@@ -54,6 +54,7 @@ def api_test_single(env: Env, num: int = 100, use_key=True):
     for _ in range(num):
         rng, subkey = jax.random.split(rng)
         state = init(subkey)
+        assert state.env_id == env.id
         assert state.legal_action_mask.sum() != 0, "legal_action_mask at init state cannot be zero."
 
         assert state._step_count == 0

--- a/pgx/_src/games/go.py
+++ b/pgx/_src/games/go.py
@@ -36,8 +36,8 @@ class GameState(NamedTuple):
         return self.step_count % 2
 
     @property
-    def size(self) -> int:
-        return int(jnp.sqrt(self.chain_id_board.shape[-1]).astype(jnp.int32).item())
+    def size(self) -> Array:
+        return jnp.sqrt(self.chain_id_board.shape[-1]).astype(jnp.int32)
 
 
 class Game:

--- a/pgx/_src/visualizer.py
+++ b/pgx/_src/visualizer.py
@@ -360,8 +360,8 @@ class Visualizer:
             from pgx._src.dwg.go import _make_go_dwg
 
             self.config["GRID_SIZE"] = 25
-            self.config["BOARD_WIDTH"] = _state._x.size  # type: ignore
-            self.config["BOARD_HEIGHT"] = _state._x.size  # type: ignore
+            self.config["BOARD_WIDTH"] = int(_state._x.size)  # type: ignore
+            self.config["BOARD_HEIGHT"] = int(_state._x.size)  # type: ignore
             self._make_dwg_group = _make_go_dwg  # type:ignore
             if (self.config["COLOR_THEME"] is None and self.config["COLOR_THEME"] == "dark") or self.config[
                 "COLOR_THEME"

--- a/pgx/go.py
+++ b/pgx/go.py
@@ -123,7 +123,7 @@ class Go(core.Env):
 
     @property
     def id(self) -> core.EnvId:
-        return f"go_{int(self.size)}x{int(self.size)}"  # type: ignore
+        return f"go_{int(self._game.size)}x{int(self._game.size)}"  # type: ignore
 
     @property
     def version(self) -> str:


### PR DESCRIPTION
Currently, this raises error:

```python
@jax.jit
def f():
    return Game(size=9).init().size

print(f())
```