### PR TITLE
[Animal Shogi] Modify the visualizer of animal shogi.

### DIFF
--- a/pgx/_src/dwg/animalshogi.py
+++ b/pgx/_src/dwg/animalshogi.py
@@ -78,13 +78,13 @@ def _make_animalshogi_dwg(dwg, state: AnimalShogiState, config: dict):
 
     # -1: EMPTY
     #  0: PAWN
-    #  1: ROOK
-    #  2: BISHOP
+    #  1: BISHOP
+    #  2: ROOK
     #  3: KING
     #  4: GOLD
     #  5: OPP_PAWN
-    #  6: OPP_ROOK
-    #  7: OPP_BISHOP
+    #  6: OPP_BISHOP
+    #  7: OPP_ROOK
     #  8: OPP_KING
     #  9: OPP_GOLD
 

--- a/pgx/_src/dwg/animalshogi.py
+++ b/pgx/_src/dwg/animalshogi.py
@@ -170,7 +170,7 @@ def _make_animalshogi_dwg(dwg, state: AnimalShogiState, config: dict):
             )
 
     # # hand
-    for i, piece_num, piece_type in zip(range(6), state._hand.flatten(), ["P", "R", "B", "P", "R", "B"]):
+    for i, piece_num, piece_type in zip(range(6), state._hand.flatten(), ["P", "B", "R", "P", "B", "R"]):
         is_black = i < 3 if state._turn == 0 else 3 <= i  # type: ignore
         _g = p1_pieces_g if is_black else p2_pieces_g
         _g.add(

--- a/pgx/animal_shogi.py
+++ b/pgx/animal_shogi.py
@@ -31,8 +31,8 @@ ROOK = jnp.int32(2)
 KING = jnp.int32(3)
 GOLD = jnp.int32(4)
 #  5: OPP_PAWN
-#  6: OPP_ROOK
-#  7: OPP_BISHOP
+#  6: OPP_BISHOP
+#  7: OPP_ROOK
 #  8: OPP_KING
 #  9: OPP_GOLD
 # fmt: off


### PR DESCRIPTION
## Description
The pieces are defined in the following P→**B**→**R** order in pgx/animal_shogi.py.
```python
PAWN = jnp.int32(0)
BISHOP = jnp.int32(1)
ROOK = jnp.int32(2)
KING = jnp.int32(3)
GOLD = jnp.int32(4)
```

However the visualizer shows the numbers of pieces in hands with the following P→**R**→**B** order.
```python
for i, piece_num, piece_type in zip(range(6), state._hand.flatten(), ["P", "R", "B", "P", "R", "B"]):
```

This difference incurs the following bug of showing incorrect hand state.

## Bug Example
In the following states, black king captures white **bishop**, but the number of **rook** in black hand is increased.
<img width="276" alt="screenshot 2024-08-22 13 42 27" src="https://github.com/user-attachments/assets/4abb3f83-a3d4-40a2-aa50-a52494ffb09c"><img width="275" alt="screenshot 2024-08-22 13 42 40" src="https://github.com/user-attachments/assets/5841039d-c2de-4f57-a135-ac3fa98be205">

In the following states, black player drops **bishop**, but the number of **rook** in black hand is decreased.

<img width="273" alt="screenshot 2024-08-22 13 43 06" src="https://github.com/user-attachments/assets/943837a3-9268-4684-8d43-6e06b458bf9d"><img width="272" alt="screenshot 2024-08-22 13 43 19" src="https://github.com/user-attachments/assets/c38d8677-500c-49a6-bf56-a41f2ba05395">

## Proposal
I propose to use consistent P→B→R order. 