### PR TITLE
[Animal Shogi] Modify the move of GOLD in animal_shogi.py

### DIFF
--- a/pgx/animal_shogi.py
+++ b/pgx/animal_shogi.py
@@ -357,7 +357,7 @@ def _can_move(piece, from_, to):
                 lambda: is_neighbour & ((dx == dy) | (dx == -dy)),  # BISHOP
                 lambda: is_neighbour & ((dx == 0) | (dy == 0)),  # ROOK
                 lambda: is_neighbour,  # KING
-                lambda: is_neighbour & ((dx != 0) | (dy != +1)),  # GOLD
+                lambda: is_neighbour & ((dx == 0) | (dy != +1)),  # GOLD
             ],
         )
 

--- a/tests/test_animal_shogi.py
+++ b/tests/test_animal_shogi.py
@@ -243,6 +243,6 @@ def test_buggy_samples():
     DOWN_LEFT_GOLD = 7 * 12 +  0
     LEFT_GOLD      = 6 * 12 +  0
     mask = state.legal_action_mask
-    assert mask[DOWN_GOLD]      == True
-    assert mask[DOWN_LEFT_GOLD] == False
-    assert mask[LEFT_GOLD]      == True
+    assert mask[DOWN_GOLD]
+    assert not mask[DOWN_LEFT_GOLD]
+    assert mask[LEFT_GOLD]

--- a/tests/test_animal_shogi.py
+++ b/tests/test_animal_shogi.py
@@ -231,7 +231,7 @@ def test_api():
 
 
 def test_buggy_samples():
-    # 1209
+    # https://github.com/sotetsuk/pgx/pull/1209
     state = init(jax.random.key(0))
     state = step(state, 3 * 12 +  6) # White: Up PAWN
     state = step(state, 0 * 12 + 11) # Black: Right Up Bishop

--- a/tests/test_animal_shogi.py
+++ b/tests/test_animal_shogi.py
@@ -223,9 +223,26 @@ def test_repetition():
     assert (state.rewards == 0).all()
 
 
-
 def test_api():
     import pgx
     env = pgx.make("animal_shogi")
     pgx.api_test(env, 3, use_key=False)
     pgx.api_test(env, 3, use_key=True)
+
+
+def test_buggy_samples():
+    # 1209
+    state = init(jax.random.key(0))
+    state = step(state, 3 * 12 +  6) # White: Up PAWN
+    state = step(state, 0 * 12 + 11) # Black: Right Up Bishop
+    state = step(state, 8 * 12 +  1) # White: Drop PAWN to 1
+    state = step(state, 3 * 12 +  3) # Black: Up Rook
+    state = step(state, 3 * 12 +  1) # White: Up PAWN (Promote to GOLD)
+    state = step(state, 1 * 12 +  7) # Black: Right King
+    DOWN_GOLD      = 4 * 12 +  0
+    DOWN_LEFT_GOLD = 7 * 12 +  0
+    LEFT_GOLD      = 6 * 12 +  0
+    mask = state.legal_action_mask
+    assert mask[DOWN_GOLD]      == True
+    assert mask[DOWN_LEFT_GOLD] == False
+    assert mask[LEFT_GOLD]      == True


### PR DESCRIPTION
## Description
The current implementation of animal_shogi.py checks the reach of GOLD with following expression.

```
is_neighbour & ((dx != 0) | (dy != +1))
```

This means the following reach.
```
***
*G*
* *
```

However, the correct reach of GOLD is the following.

```
***
*G*
 * 
```

## Proposal

Therefore, I propose to modify the expression as follows.
```
is_neighbour & ((dx == 0) | (dy != +1))
```

## Bug Example
I found this bug because of the following move of white gold, which led to mate.

<img width="275" alt="screenshot 2024-08-23 14 43 45" src="https://github.com/user-attachments/assets/acc311be-ac33-45f1-8c9a-ddedb2be1d84"><img width="282" alt="screenshot 2024-08-23 14 43 59" src="https://github.com/user-attachments/assets/38382a51-f08f-463c-a5e5-01d3c2726e9e">

