### PR TITLE
[Animal Shogi] Dropping PAWN on the final rank is legal.

### DIFF
--- a/pgx/animal_shogi.py
+++ b/pgx/animal_shogi.py
@@ -303,7 +303,6 @@ def _legal_action_mask(state: State):
     def is_legal_drop(action: Action):
         ok = state._board[action.to] == EMPTY
         ok &= state._hand[0, action.drop_piece] > 0
-        ok &= (action.drop_piece != PAWN) | (action.to % 4 != 0)
         ok &= ~_is_checked(_step_drop(state, action))
         return ok
 

--- a/tests/test_animal_shogi.py
+++ b/tests/test_animal_shogi.py
@@ -247,7 +247,7 @@ def test_buggy_samples():
     assert not mask[DOWN_LEFT_GOLD]
     assert mask[LEFT_GOLD]
 
-    # (Add link later)
+    # https://github.com/sotetsuk/pgx/pull/1218
     state = init(jax.random.key(0))
     state = step(state, 3 * 12 +  6) # White: Up PAWN
     state = step(state, 0 * 12 + 11) # Black: Right Up Bishop

--- a/tests/test_animal_shogi.py
+++ b/tests/test_animal_shogi.py
@@ -246,3 +246,10 @@ def test_buggy_samples():
     assert mask[DOWN_GOLD]
     assert not mask[DOWN_LEFT_GOLD]
     assert mask[LEFT_GOLD]
+
+    # (Add link later)
+    state = init(jax.random.key(0))
+    state = step(state, 3 * 12 +  6) # White: Up PAWN
+    state = step(state, 0 * 12 + 11) # Black: Right Up Bishop
+    DROP_PAWN_TO_0 = 8 * 12 +  0
+    assert state.legal_action_mask[DROP_PAWN_TO_0]


### PR DESCRIPTION
## Description
In animal shogi, dropping PAWN on the final rank is legal.

> standard restrictions on where one may drop a Chick, such as not being allowed to give immediate checkmate, have two Chicks on a file, or drop the Chick on the final rank, do not apply. [^1]

However, the current implementation forbids dropping PAWN on final rank.

## Proposal
Make dropping PAWN on the final rank legal.

## Note 
I also added a simple test to ‎`test_buggy_samples`‎ in test_animal_shogi.py.

## See also
An interesting fact is reported that dropping PAWN on final rank is sometimes the only winning move.

> there are positions in which “dropping a hiyoko piece on the promote zone” is the only winning move. [^2]

[^1]: [Dōbutsu shōgi (English Wikipedia)](https://en.wikipedia.org/wiki/D%C5%8Dbutsu_sh%C5%8Dgi#:~:text=standard%20restrictions%20on%20where%20one%20may%20drop%20a%20Chick%2C%20such%20as%20not%20being%20allowed%20to%20give%20immediate%20checkmate%2C%20have%20two%20Chicks%20on%20a%20file%2C%20or%20drop%20the%20Chick%20on%20the%20final%20rank%2C%20do%20not%20apply.)
[^2]: [田中哲朗. "「どうぶつしょうぎ」 の完全解析." 研究報告ゲーム情報学 (GI) 2009.3 (2009): 1-8.](https://www.tanaka.ecc.u-tokyo.ac.jp/ktanaka/dobutsushogi/animal-private.pdf)