### PR TITLE
[CI] Drop py3.8 and test py3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: "${{ matrix.os }}"
     strategy:
       matrix:
-        python-version: ["3.8", "3.12"]
+        python-version: ["3.9", "3.12"]
         os: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: "${{ matrix.os }}"
     strategy:
       matrix:
-        python-version: ["3.12"]
+        python-version: ["3.8", "3.12"]
         os: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </div>
 
 <p align="center">
-<a href="https://www.python.org/"><img alt="python" src="https://img.shields.io/badge/python-3.8+-blue?logo=python&logoColor=ffdd54"></a>
+<a href="https://www.python.org/"><img alt="python" src="https://img.shields.io/badge/python-3.9+-blue?logo=python&logoColor=ffdd54"></a>
 <a href="https://pypi.org/project/pgx/"><img alt="pypi" src="https://badge.fury.io/py/pgx.svg"></a>
 <a href="https://opensource.org/licenses/Apache-2.0"><img alt="license" src="https://img.shields.io/badge/license-Apache%202.0-green.svg"></a>
 <a href="https://github.com/sotetsuk/pgx/actions/workflows/ci.yml"><img alt="ci" src="https://github.com/sotetsuk/pgx/actions/workflows/ci.yml/badge.svg"></a>

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </div>
 
 <p align="center">
-<a href="https://www.python.org/"><img alt="python" src="https://img.shields.io/badge/python-3.8+-blue"></a>
+<a href="https://www.python.org/"><img alt="python" src="https://img.shields.io/badge/python-3.8+-blue&logo=python"></a>
 <a href="https://pypi.org/project/pgx/"><img alt="pypi" src="https://badge.fury.io/py/pgx.svg"></a>
 <a href="https://opensource.org/licenses/Apache-2.0"><img alt="license" src="https://img.shields.io/badge/license-Apache%202.0-green.svg"></a>
 <a href="https://github.com/sotetsuk/pgx/actions/workflows/ci.yml"><img alt="ci" src="https://github.com/sotetsuk/pgx/actions/workflows/ci.yml/badge.svg"></a>

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </div>
 
 <p align="center">
-<a href="https://www.python.org/"><img alt="python" src="https://img.shields.io/badge/python-3.8%20%7C%203.9%20%7C%203.10%20%7C%203.11%20%7C%203.12-blue"></a>
+<a href="https://www.python.org/"><img alt="python" src="https://img.shields.io/badge/python-3.8+-blue"></a>
 <a href="https://pypi.org/project/pgx/"><img alt="pypi" src="https://badge.fury.io/py/pgx.svg"></a>
 <a href="https://opensource.org/licenses/Apache-2.0"><img alt="license" src="https://img.shields.io/badge/license-Apache%202.0-green.svg"></a>
 <a href="https://github.com/sotetsuk/pgx/actions/workflows/ci.yml"><img alt="ci" src="https://github.com/sotetsuk/pgx/actions/workflows/ci.yml/badge.svg"></a>

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </div>
 
 <p align="center">
-<a href="https://www.python.org/"><img alt="python" src="https://img.shields.io/badge/python-3.8+-blue&logo=python"></a>
+<a href="https://www.python.org/"><img alt="python" src="https://img.shields.io/badge/python-3.8+-blue?logo=python"></a>
 <a href="https://pypi.org/project/pgx/"><img alt="pypi" src="https://badge.fury.io/py/pgx.svg"></a>
 <a href="https://opensource.org/licenses/Apache-2.0"><img alt="license" src="https://img.shields.io/badge/license-Apache%202.0-green.svg"></a>
 <a href="https://github.com/sotetsuk/pgx/actions/workflows/ci.yml"><img alt="ci" src="https://github.com/sotetsuk/pgx/actions/workflows/ci.yml/badge.svg"></a>

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </div>
 
 <p align="center">
-<a href="https://www.python.org/"><img alt="python" src="https://img.shields.io/badge/python-3.8+-blue?logo=python"></a>
+<a href="https://www.python.org/"><img alt="python" src="https://img.shields.io/badge/python-3.8+-blue?logo=python&logoColor=ffdd54"></a>
 <a href="https://pypi.org/project/pgx/"><img alt="pypi" src="https://badge.fury.io/py/pgx.svg"></a>
 <a href="https://opensource.org/licenses/Apache-2.0"><img alt="license" src="https://img.shields.io/badge/license-Apache%202.0-green.svg"></a>
 <a href="https://github.com/sotetsuk/pgx/actions/workflows/ci.yml"><img alt="ci" src="https://github.com/sotetsuk/pgx/actions/workflows/ci.yml/badge.svg"></a>


### PR DESCRIPTION
Now JAX support only 3.10+ (from 0.4.31)