### PR TITLE
[Chess] Reduce `_is_checked` call

### DIFF
--- a/pgx/_src/games/chess.py
+++ b/pgx/_src/games/chess.py
@@ -487,7 +487,6 @@ def _legal_action_mask(state: GameState) -> Array:
         def is_ok(label):
             return ~_is_checked(_apply_move(state, Action._from_label(label)))
 
-        ok &= ~_is_checked(state)
         ok &= is_ok(jnp.int32([2366, 2367])).all()
 
         return ok
@@ -504,7 +503,6 @@ def _legal_action_mask(state: GameState) -> Array:
         def is_ok(label):
             return ~_is_checked(_apply_move(state, Action._from_label(label)))
 
-        ok &= ~_is_checked(state)
         ok &= is_ok(jnp.int32([2364, 2365])).all()
 
         return ok
@@ -515,8 +513,9 @@ def _legal_action_mask(state: GameState) -> Array:
     mask = mask.at[actions].set(TRUE)
 
     # castling
-    mask = mask.at[2364].set(mask[2364] | can_castle_queen_side())
-    mask = mask.at[2367].set(mask[2367] | can_castle_king_side())
+    not_checked = ~_is_checked(state)
+    mask = mask.at[2364].set(mask[2364] | (not_checked & can_castle_queen_side()))
+    mask = mask.at[2367].set(mask[2367] | (not_checked & can_castle_king_side()))
 
     # set en passant
     actions = legal_en_passants()

--- a/pgx/_src/games/chess.py
+++ b/pgx/_src/games/chess.py
@@ -486,7 +486,7 @@ def _legal_action_mask(state: GameState) -> Array:
     can_castle_queen_side = state.can_castle_queen_side[0]
     can_castle_queen_side &= (b[0] == ROOK) & (b[8] == EMPTY) & (b[16] == EMPTY) & (b[24] == EMPTY) & (b[32] == KING)
     can_castle_king_side = state.can_castle_king_side[0]
-    can_castle_king_side &= (b[32] == KING) & (b[40] == EMPTY) & (b[48] == EMPTY) & (b[56] == ROOK) 
+    can_castle_king_side &= (b[32] == KING) & (b[40] == EMPTY) & (b[48] == EMPTY) & (b[56] == ROOK)
     not_checked = ~jax.vmap(_is_attacked, in_axes=(None, 0))(state, jnp.int32([16, 24, 32, 40, 48]))
     mask = mask.at[2364].set(mask[2364] | (can_castle_queen_side & not_checked[:3].all()))
     mask = mask.at[2367].set(mask[2367] | (can_castle_king_side & not_checked[2:].all()))

--- a/pgx/_src/games/chess.py
+++ b/pgx/_src/games/chess.py
@@ -513,7 +513,7 @@ def _legal_action_mask(state: GameState) -> Array:
     mask = mask.at[actions].set(TRUE)
 
     # castling
-    not_checked = ~_is_checked(state)
+    not_checked = ~_is_attacked(state, 32)
     mask = mask.at[2364].set(mask[2364] | (not_checked & can_castle_queen_side()))
     mask = mask.at[2367].set(mask[2367] | (not_checked & can_castle_king_side()))
 

--- a/pgx/_src/games/chess.py
+++ b/pgx/_src/games/chess.py
@@ -515,8 +515,8 @@ def _legal_action_mask(state: GameState) -> Array:
     mask = mask.at[actions].set(TRUE)
 
     # castling
-    mask = mask.at[2364].set(jax.lax.select(can_castle_queen_side(), TRUE, mask[2364]))
-    mask = mask.at[2367].set(jax.lax.select(can_castle_king_side(), TRUE, mask[2367]))
+    mask = mask.at[2364].set(mask[2364] | can_castle_queen_side())
+    mask = mask.at[2367].set(mask[2367] | can_castle_king_side())
 
     # set en passant
     actions = legal_en_passants()


### PR DESCRIPTION
c.f. #1230 

| fn| jaxpr lines | time |
|:---|---:|:---|
| `_legal_action_mask` | 2467 | 728.2ms |
| `_flip` | 92 | 33.4ms |
| `_is_checked` | 206 | 68.8ms |
| `_is_pseudo_legal` | 136 | 40.4ms |
| `_hash_castling_en_passant` | 37 | 18.5ms |
| `_apply_move` | 331 | 107.0ms |
| `_update_history` | 57 | 30.9ms |