### PR TITLE
[Chess] Summarize `_is_checked` calls

### DIFF
--- a/pgx/_src/games/chess.py
+++ b/pgx/_src/games/chess.py
@@ -465,12 +465,12 @@ def _legal_action_mask(state: GameState) -> Array:
             return jax.lax.select(ok, a._to_label(), -1)
 
         return legal_labels(jnp.int32([to - 9, to + 7]))
-    
+
     @jax.vmap
     def is_not_checked(label):
-        a = Action._from_label(label) 
+        a = Action._from_label(label)
         return ~_is_checked(_apply_move(state, a))
- 
+
     # normal move and en passant
     a1 = legal_norml_moves(state.possible_piece_positions[0]).flatten()
     a2 = legal_en_passants()


### PR DESCRIPTION
#1231 

| fn| jaxpr lines | time |
|:---|---:|:---|
| `_legal_action_mask` | 1689 | 468.3ms |
| `_flip` | 92 | 38.0ms |
| `_is_checked` | 206 | 59.3ms |
| `_is_pseudo_legal` | 136 | 39.2ms |
| `_hash_castling_en_passant` | 37 | 18.6ms |
| `_apply_move` | 331 | 98.8ms |
| `_update_history` | 57 | 30.5ms |