### PR TITLE
[Chess] Enhance `CAN_MOVE`

### DIFF
--- a/pgx/_src/games/chess.py
+++ b/pgx/_src/games/chess.py
@@ -20,9 +20,9 @@ from jax import Array
 
 from pgx._src.games.chess_utils import (  # type: ignore
     BETWEEN,
+    LEGAL_DEST,
     CAN_MOVE,
-    MOVE_OK,
-    CAN_MOVE_ANY,
+    LEGAL_DEST_ANY,
     INIT_LEGAL_ACTION_MASK,
     INIT_POSSIBLE_PIECE_POSITIONS,
     PLANE_MAP,
@@ -435,7 +435,7 @@ def _legal_action_mask(state: GameState) -> Array:
             ok = (from_ >= 0) & (piece > 0) & (to >= 0) & _is_pseudo_legal(state, a)
             return jax.lax.select(ok, a._to_label(), -1)
 
-        return legal_label(CAN_MOVE[piece, from_])
+        return legal_label(LEGAL_DEST[piece, from_])
 
     def legal_underpromotions(mask):
         # from_ = 6 14 22 30 38 46 54 62
@@ -504,7 +504,7 @@ def _is_attacked(state: GameState, pos):
     def can_move(to):
         ok = (to >= 0) & (state.board[to] < 0)  # should be opponent's
         piece = jnp.abs(state.board[to])
-        ok &= MOVE_OK[piece, pos, to]
+        ok &= CAN_MOVE[piece, pos, to]
         between_ixs = BETWEEN[pos, to]
         ok &= ((between_ixs < 0) | (state.board[between_ixs] == EMPTY)).all()
         # For pawn, it should be the forward diagonal direction
@@ -512,7 +512,7 @@ def _is_attacked(state: GameState, pos):
         ok &= ~((piece == PAWN) & (to // 8 == pos // 8))  # should move diagnally to capture the king
         return ok
 
-    return can_move(CAN_MOVE_ANY[pos, :]).any()
+    return can_move(LEGAL_DEST_ANY[pos, :]).any()
 
 
 def _is_checked(state: GameState):
@@ -524,7 +524,7 @@ def _is_checked(state: GameState):
 def _is_pseudo_legal(state: GameState, a: Action):
     piece = state.board[a.from_]
     ok = (piece >= 0) & (state.board[a.to] <= 0)
-    ok &= MOVE_OK[piece, a.from_, a.to]
+    ok &= CAN_MOVE[piece, a.from_, a.to]
     between_ixs = BETWEEN[a.from_, a.to]
     ok &= ((between_ixs < 0) | (state.board[between_ixs] == EMPTY)).all()
     # filter pawn move

--- a/pgx/_src/games/chess.py
+++ b/pgx/_src/games/chess.py
@@ -21,6 +21,7 @@ from jax import Array
 from pgx._src.games.chess_utils import (  # type: ignore
     BETWEEN,
     CAN_MOVE,
+    MOVE_OK,
     CAN_MOVE_ANY,
     INIT_LEGAL_ACTION_MASK,
     INIT_POSSIBLE_PIECE_POSITIONS,
@@ -503,7 +504,7 @@ def _is_attacked(state: GameState, pos):
     def can_move(to):
         ok = (to >= 0) & (state.board[to] < 0)  # should be opponent's
         piece = jnp.abs(state.board[to])
-        ok &= (CAN_MOVE[piece, pos] == to).any()
+        ok &= MOVE_OK[piece, pos, to]
         between_ixs = BETWEEN[pos, to]
         ok &= ((between_ixs < 0) | (state.board[between_ixs] == EMPTY)).all()
         # For pawn, it should be the forward diagonal direction
@@ -523,7 +524,7 @@ def _is_checked(state: GameState):
 def _is_pseudo_legal(state: GameState, a: Action):
     piece = state.board[a.from_]
     ok = (piece >= 0) & (state.board[a.to] <= 0)
-    ok &= (CAN_MOVE[piece, a.from_] == a.to).any()
+    ok &= MOVE_OK[piece, a.from_, a.to]
     between_ixs = BETWEEN[a.from_, a.to]
     ok &= ((between_ixs < 0) | (state.board[between_ixs] == EMPTY)).all()
     # filter pawn move

--- a/pgx/_src/games/chess.py
+++ b/pgx/_src/games/chess.py
@@ -20,11 +20,11 @@ from jax import Array
 
 from pgx._src.games.chess_utils import (  # type: ignore
     BETWEEN,
-    LEGAL_DEST,
     CAN_MOVE,
-    LEGAL_DEST_ANY,
     INIT_LEGAL_ACTION_MASK,
     INIT_POSSIBLE_PIECE_POSITIONS,
+    LEGAL_DEST,
+    LEGAL_DEST_ANY,
     PLANE_MAP,
     TO_MAP,
     ZOBRIST_BOARD,

--- a/pgx/_src/games/chess_utils.py
+++ b/pgx/_src/games/chess_utils.py
@@ -66,6 +66,7 @@ for from_ in range(64):
 
 
 CAN_MOVE = -np.ones((7, 64, 27), np.int32)
+MOVE_OK = jnp.zeros((7, 64, 64), dtype=np.bool_)
 # usage: CAN_MOVE[piece, from_x, from_y]
 # CAN_MOVE[0, :, :] are all -1
 # Note that the board is not symmetric about the center (different from shogi)
@@ -87,6 +88,8 @@ for from_ in range(64):
             legal_dst.append(to)
     assert len(legal_dst) <= 8
     CAN_MOVE[1, from_, : len(legal_dst)] = legal_dst
+    for a in legal_dst:
+        MOVE_OK = MOVE_OK.at[1, from_, a].set(True)
 # KNIGHT
 for from_ in range(64):
     r0, c0 = from_ % 8, from_ // 8
@@ -99,6 +102,8 @@ for from_ in range(64):
             legal_dst.append(to)
     assert len(legal_dst) <= 27
     CAN_MOVE[2, from_, : len(legal_dst)] = legal_dst
+    for a in legal_dst:
+        MOVE_OK = MOVE_OK.at[2, from_, a].set(True)
 # BISHOP
 for from_ in range(64):
     r0, c0 = from_ % 8, from_ // 8
@@ -111,6 +116,8 @@ for from_ in range(64):
             legal_dst.append(to)
     assert len(legal_dst) <= 27
     CAN_MOVE[3, from_, : len(legal_dst)] = legal_dst
+    for a in legal_dst:
+        MOVE_OK = MOVE_OK.at[3, from_, a].set(True)
 # ROOK
 for from_ in range(64):
     r0, c0 = from_ % 8, from_ // 8
@@ -123,6 +130,8 @@ for from_ in range(64):
             legal_dst.append(to)
     assert len(legal_dst) <= 27
     CAN_MOVE[4, from_, : len(legal_dst)] = legal_dst
+    for a in legal_dst:
+        MOVE_OK = MOVE_OK.at[4, from_, a].set(True)
 # QUEEN
 for from_ in range(64):
     r0, c0 = from_ % 8, from_ // 8
@@ -137,6 +146,8 @@ for from_ in range(64):
             legal_dst.append(to)
     assert len(legal_dst) <= 27
     CAN_MOVE[5, from_, : len(legal_dst)] = legal_dst
+    for a in legal_dst:
+        MOVE_OK = MOVE_OK.at[5, from_, a].set(True)
 # KING
 for from_ in range(64):
     r0, c0 = from_ % 8, from_ // 8
@@ -154,6 +165,8 @@ for from_ in range(64):
     #     legal_dst += [23, 55]
     assert len(legal_dst) <= 8
     CAN_MOVE[6, from_, : len(legal_dst)] = legal_dst
+    for a in legal_dst:
+        MOVE_OK = MOVE_OK.at[6, from_, a].set(True)
 
 assert (CAN_MOVE[0, :, :] == -1).all()
 

--- a/pgx/_src/games/chess_utils.py
+++ b/pgx/_src/games/chess_utils.py
@@ -66,7 +66,7 @@ for from_ in range(64):
 
 
 LEGAL_DEST = -np.ones((7, 64, 27), np.int32)
-CAN_MOVE = jnp.zeros((7, 64, 64), dtype=np.bool_)
+CAN_MOVE = np.zeros((7, 64, 64), dtype=np.bool_)
 # usage: LEGAL_DEST[piece, from_x, from_y]
 # LEGAL_DEST[0, :, :] are all -1
 # Note that the board is not symmetric about the center (different from shogi)
@@ -89,7 +89,7 @@ for from_ in range(64):
     assert len(legal_dst) <= 8
     LEGAL_DEST[1, from_, : len(legal_dst)] = legal_dst
     for a in legal_dst:
-        CAN_MOVE = CAN_MOVE.at[1, from_, a].set(True)
+        CAN_MOVE[1, from_, a] = True
 # KNIGHT
 for from_ in range(64):
     r0, c0 = from_ % 8, from_ // 8
@@ -103,7 +103,7 @@ for from_ in range(64):
     assert len(legal_dst) <= 27
     LEGAL_DEST[2, from_, : len(legal_dst)] = legal_dst
     for a in legal_dst:
-        CAN_MOVE = CAN_MOVE.at[2, from_, a].set(True)
+        CAN_MOVE[2, from_, a] = True
 # BISHOP
 for from_ in range(64):
     r0, c0 = from_ % 8, from_ // 8
@@ -117,7 +117,7 @@ for from_ in range(64):
     assert len(legal_dst) <= 27
     LEGAL_DEST[3, from_, : len(legal_dst)] = legal_dst
     for a in legal_dst:
-        CAN_MOVE = CAN_MOVE.at[3, from_, a].set(True)
+        CAN_MOVE[3, from_, a] = True
 # ROOK
 for from_ in range(64):
     r0, c0 = from_ % 8, from_ // 8
@@ -131,7 +131,7 @@ for from_ in range(64):
     assert len(legal_dst) <= 27
     LEGAL_DEST[4, from_, : len(legal_dst)] = legal_dst
     for a in legal_dst:
-        CAN_MOVE = CAN_MOVE.at[4, from_, a].set(True)
+        CAN_MOVE[4, from_, a] = True
 # QUEEN
 for from_ in range(64):
     r0, c0 = from_ % 8, from_ // 8
@@ -147,7 +147,7 @@ for from_ in range(64):
     assert len(legal_dst) <= 27
     LEGAL_DEST[5, from_, : len(legal_dst)] = legal_dst
     for a in legal_dst:
-        CAN_MOVE = CAN_MOVE.at[5, from_, a].set(True)
+        CAN_MOVE[5, from_, a] = True
 # KING
 for from_ in range(64):
     r0, c0 = from_ % 8, from_ // 8
@@ -166,7 +166,7 @@ for from_ in range(64):
     assert len(legal_dst) <= 8
     LEGAL_DEST[6, from_, : len(legal_dst)] = legal_dst
     for a in legal_dst:
-        CAN_MOVE = CAN_MOVE.at[6, from_, a].set(True)
+        CAN_MOVE[6, from_, a] = True
 
 assert (LEGAL_DEST[0, :, :] == -1).all()
 
@@ -218,6 +218,7 @@ TO_MAP = jnp.array(TO_MAP)
 PLANE_MAP = jnp.array(PLANE_MAP)
 LEGAL_DEST = jnp.array(LEGAL_DEST)
 LEGAL_DEST_ANY = jnp.array(LEGAL_DEST_ANY)
+CAN_MOVE = jnp.array(CAN_MOVE)
 BETWEEN = jnp.array(BETWEEN)
 INIT_LEGAL_ACTION_MASK = jnp.array(INIT_LEGAL_ACTION_MASK)
 INIT_POSSIBLE_PIECE_POSITIONS = jnp.int32(

--- a/pgx/_src/games/chess_utils.py
+++ b/pgx/_src/games/chess_utils.py
@@ -65,10 +65,10 @@ for from_ in range(64):
         PLANE_MAP[from_, to] = plane
 
 
-CAN_MOVE = -np.ones((7, 64, 27), np.int32)
-MOVE_OK = jnp.zeros((7, 64, 64), dtype=np.bool_)
-# usage: CAN_MOVE[piece, from_x, from_y]
-# CAN_MOVE[0, :, :] are all -1
+LEGAL_DEST = -np.ones((7, 64, 27), np.int32)
+CAN_MOVE = jnp.zeros((7, 64, 64), dtype=np.bool_)
+# usage: LEGAL_DEST[piece, from_x, from_y]
+# LEGAL_DEST[0, :, :] are all -1
 # Note that the board is not symmetric about the center (different from shogi)
 # You can imagine that the viewpoint is always from the white side.
 # Except PAWN, the moves are symmetric about the center.
@@ -87,9 +87,9 @@ for from_ in range(64):
         if (r0 == 1 or r0 == 6) and (np.abs(c1 - c0) == 0 and np.abs(r1 - r0) == 2):
             legal_dst.append(to)
     assert len(legal_dst) <= 8
-    CAN_MOVE[1, from_, : len(legal_dst)] = legal_dst
+    LEGAL_DEST[1, from_, : len(legal_dst)] = legal_dst
     for a in legal_dst:
-        MOVE_OK = MOVE_OK.at[1, from_, a].set(True)
+        CAN_MOVE = CAN_MOVE.at[1, from_, a].set(True)
 # KNIGHT
 for from_ in range(64):
     r0, c0 = from_ % 8, from_ // 8
@@ -101,9 +101,9 @@ for from_ in range(64):
         if np.abs(r1 - r0) == 2 and np.abs(c1 - c0) == 1:
             legal_dst.append(to)
     assert len(legal_dst) <= 27
-    CAN_MOVE[2, from_, : len(legal_dst)] = legal_dst
+    LEGAL_DEST[2, from_, : len(legal_dst)] = legal_dst
     for a in legal_dst:
-        MOVE_OK = MOVE_OK.at[2, from_, a].set(True)
+        CAN_MOVE = CAN_MOVE.at[2, from_, a].set(True)
 # BISHOP
 for from_ in range(64):
     r0, c0 = from_ % 8, from_ // 8
@@ -115,9 +115,9 @@ for from_ in range(64):
         if np.abs(r1 - r0) == np.abs(c1 - c0):
             legal_dst.append(to)
     assert len(legal_dst) <= 27
-    CAN_MOVE[3, from_, : len(legal_dst)] = legal_dst
+    LEGAL_DEST[3, from_, : len(legal_dst)] = legal_dst
     for a in legal_dst:
-        MOVE_OK = MOVE_OK.at[3, from_, a].set(True)
+        CAN_MOVE = CAN_MOVE.at[3, from_, a].set(True)
 # ROOK
 for from_ in range(64):
     r0, c0 = from_ % 8, from_ // 8
@@ -129,9 +129,9 @@ for from_ in range(64):
         if np.abs(r1 - r0) == 0 or np.abs(c1 - c0) == 0:
             legal_dst.append(to)
     assert len(legal_dst) <= 27
-    CAN_MOVE[4, from_, : len(legal_dst)] = legal_dst
+    LEGAL_DEST[4, from_, : len(legal_dst)] = legal_dst
     for a in legal_dst:
-        MOVE_OK = MOVE_OK.at[4, from_, a].set(True)
+        CAN_MOVE = CAN_MOVE.at[4, from_, a].set(True)
 # QUEEN
 for from_ in range(64):
     r0, c0 = from_ % 8, from_ // 8
@@ -145,9 +145,9 @@ for from_ in range(64):
         if np.abs(r1 - r0) == np.abs(c1 - c0):
             legal_dst.append(to)
     assert len(legal_dst) <= 27
-    CAN_MOVE[5, from_, : len(legal_dst)] = legal_dst
+    LEGAL_DEST[5, from_, : len(legal_dst)] = legal_dst
     for a in legal_dst:
-        MOVE_OK = MOVE_OK.at[5, from_, a].set(True)
+        CAN_MOVE = CAN_MOVE.at[5, from_, a].set(True)
 # KING
 for from_ in range(64):
     r0, c0 = from_ % 8, from_ // 8
@@ -164,24 +164,24 @@ for from_ in range(64):
     # if from_ == 39:
     #     legal_dst += [23, 55]
     assert len(legal_dst) <= 8
-    CAN_MOVE[6, from_, : len(legal_dst)] = legal_dst
+    LEGAL_DEST[6, from_, : len(legal_dst)] = legal_dst
     for a in legal_dst:
-        MOVE_OK = MOVE_OK.at[6, from_, a].set(True)
+        CAN_MOVE = CAN_MOVE.at[6, from_, a].set(True)
 
-assert (CAN_MOVE[0, :, :] == -1).all()
+assert (LEGAL_DEST[0, :, :] == -1).all()
 
-CAN_MOVE_ANY = -np.ones((64, 35), np.int32)
+LEGAL_DEST_ANY = -np.ones((64, 35), np.int32)
 for from_ in range(64):
     legal_dst = []
     for i in range(27):
-        to = CAN_MOVE[5, from_, i]  # QUEEN
+        to = LEGAL_DEST[5, from_, i]  # QUEEN
         if to >= 0:
             legal_dst.append(to)
     for i in range(27):
-        to = CAN_MOVE[2, from_, i]  # KNIGHT
+        to = LEGAL_DEST[2, from_, i]  # KNIGHT
         if to >= 0:
             legal_dst.append(to)
-    CAN_MOVE_ANY[from_, : len(legal_dst)] = legal_dst
+    LEGAL_DEST_ANY[from_, : len(legal_dst)] = legal_dst
 
 
 # Between
@@ -216,8 +216,8 @@ assert INIT_LEGAL_ACTION_MASK.sum() == 20
 
 TO_MAP = jnp.array(TO_MAP)
 PLANE_MAP = jnp.array(PLANE_MAP)
-CAN_MOVE = jnp.array(CAN_MOVE)
-CAN_MOVE_ANY = jnp.array(CAN_MOVE_ANY)
+LEGAL_DEST = jnp.array(LEGAL_DEST)
+LEGAL_DEST_ANY = jnp.array(LEGAL_DEST_ANY)
 BETWEEN = jnp.array(BETWEEN)
 INIT_LEGAL_ACTION_MASK = jnp.array(INIT_LEGAL_ACTION_MASK)
 INIT_POSSIBLE_PIECE_POSITIONS = jnp.int32(


### PR DESCRIPTION
#1232 #1233

<img width="329" alt="image" src="https://github.com/user-attachments/assets/026ec710-c503-43ff-b371-87b8c8514576">

| fn| jaxpr lines | time |
|:---|---:|:---|
| `_legal_action_mask` | 1674 | 427.0ms |
| `_flip` | 92 | 28.4ms |
| `_is_checked` | 203 | 52.8ms |
| `_is_pseudo_legal` | 134 | 35.8ms |
| `_hash_castling_en_passant` | 37 | 17.6ms |
| `_apply_move` | 331 | 92.8ms |
| `_update_history` | 57 | 27.5ms |