### PR TITLE
[Chess] Simplify `legal_underpromotions`

### DIFF
--- a/pgx/_src/games/chess.py
+++ b/pgx/_src/games/chess.py
@@ -448,8 +448,7 @@ def _legal_action_mask(state: GameState) -> Array:
         # from_ = 6 14 22 30 38 46 54 62
         # plane = 0 ... 8
         labels = jnp.int32([from_ * 73 + i for i in range(9) for from_ in [6, 14, 22, 30, 38, 46, 54, 62]])
-        ok_labels = legal_labels(labels)
-        return ok_labels.flatten()
+        return legal_labels(labels)
 
     def legal_en_passants():
         to = state.en_passant

--- a/pgx/_src/games/chess.py
+++ b/pgx/_src/games/chess.py
@@ -438,14 +438,6 @@ def _legal_action_mask(state: GameState) -> Array:
         return legal_label(LEGAL_DEST[piece, from_])
 
     def legal_underpromotions(mask):
-        # from_ = 6 14 22 30 38 46 54 62
-        # plane = 0 ... 8
-        @jax.vmap
-        def make_labels(from_):
-            return from_ * 73 + jnp.arange(9)
-
-        labels = make_labels(jnp.int32([6, 14, 22, 30, 38, 46, 54, 62])).flatten()
-
         @jax.vmap
         def legal_labels(label):
             a = Action._from_label(label)
@@ -453,6 +445,9 @@ def _legal_action_mask(state: GameState) -> Array:
             ok &= mask[Action(from_=a.from_, to=a.to)._to_label()]
             return jax.lax.select(ok, label, -1)
 
+        # from_ = 6 14 22 30 38 46 54 62
+        # plane = 0 ... 8
+        labels = jnp.int32([from_ * 73 + i for i in range(9) for from_ in [6, 14, 22, 30, 38, 46, 54, 62]])
         ok_labels = legal_labels(labels)
         return ok_labels.flatten()
 

--- a/pgx/_src/games/chess.py
+++ b/pgx/_src/games/chess.py
@@ -445,8 +445,7 @@ def _legal_action_mask(state: GameState) -> Array:
             ok &= mask[Action(from_=a.from_, to=a.to)._to_label()]
             return jax.lax.select(ok, label, -1)
 
-        # from_ = 6 14 22 30 38 46 54 62
-        # plane = 0 ... 8
+        # from_ = 6 14 ... 62, plane = 0 1 ... 8
         labels = jnp.int32([from_ * 73 + i for i in range(9) for from_ in [6, 14, 22, 30, 38, 46, 54, 62]])
         return legal_labels(labels)
 


### PR DESCRIPTION
| fn| jaxpr lines | time |
|:---|---:|:---|
| `_legal_action_mask` | 1631 | 485.1ms |
| `_flip` | 91 | 25.2ms |
| `_is_checked` | 203 | 53.4ms |
| `_is_pseudo_legal` | 134 | 35.0ms |
| `_hash_castling_en_passant` | 37 | 17.4ms |
| `_apply_move` | 258 | 69.3ms |
| `_update_history` | 57 | 28.6ms |
