### PR TITLE
[Chess] Remove `_is_pseudo_legal`

### DIFF
--- a/pgx/_src/games/chess.py
+++ b/pgx/_src/games/chess.py
@@ -416,8 +416,8 @@ def _legal_action_mask(state: GameState) -> Array:
             ok = (from_ >= 0) & (piece > 0) & (to >= 0) & (state.board[to] <= 0)
             between_ixs = BETWEEN[from_, to]
             ok &= CAN_MOVE[piece, from_, to] & ((between_ixs < 0) | (state.board[between_ixs] == EMPTY)).all()
-            in_same_col = (to - from_) % 8 == 0
-            pawn_should = (in_same_col & (state.board[to] == EMPTY)) | (~in_same_col & (state.board[to] < 0))
+            r0, c0, r1, c1 = from_ % 8, from_ // 8, to % 8, to // 8
+            pawn_should = ((c1 == c0) & (state.board[to] == EMPTY)) | ((c1 != c0) & (state.board[to] < 0))
             ok &= (piece != PAWN) | pawn_should
             return jax.lax.select(ok, Action(from_=from_, to=to)._to_label(), -1)
 

--- a/pgx/_src/games/chess.py
+++ b/pgx/_src/games/chess.py
@@ -419,9 +419,10 @@ def _legal_action_mask(state: GameState) -> Array:
             between_ixs = BETWEEN[a.from_, a.to]
             ok &= ((between_ixs < 0) | (state.board[between_ixs] == EMPTY)).all()
             # filter pawn move
-            ok &= ~((piece == PAWN) & ((a.to % 8) < (a.from_ % 8)))  # should move forward
-            ok &= ~((piece == PAWN) & (jnp.abs(a.to - a.from_) <= 2) & (state.board[a.to] < 0))  # cannot move up if occupied by opponent
-            ok &= ~((piece == PAWN) & (jnp.abs(a.to - a.from_) > 2) & (state.board[a.to] >= 0))  # cannot move diagnally without capturing
+            pawn_should = ~(((a.to % 8) < (a.from_ % 8)))  # should move forward
+            pawn_should &= ~((jnp.abs(a.to - a.from_) <= 2) & (state.board[a.to] < 0))  # cannot move up if occupied by opponent
+            pawn_should &= ~((jnp.abs(a.to - a.from_) > 2) & (state.board[a.to] >= 0))  # cannot move diagnally without capturing
+            ok &= (piece != PAWN) | pawn_should
             return jax.lax.select(ok, a._to_label(), -1)
 
         return legal_label(LEGAL_DEST[piece, from_])

--- a/pgx/_src/games/chess.py
+++ b/pgx/_src/games/chess.py
@@ -415,14 +415,14 @@ def _legal_action_mask(state: GameState) -> Array:
         def legal_label(to):
             a = Action(from_=from_, to=to)
             ok = (from_ >= 0) & (piece > 0) & (to >= 0) & (state.board[to] <= 0)
-            ok &= CAN_MOVE[piece, a.from_, a.to]
-            between_ixs = BETWEEN[a.from_, a.to]
+            ok &= CAN_MOVE[piece, from_, to]
+            between_ixs = BETWEEN[from_, to]
             ok &= ((between_ixs < 0) | (state.board[between_ixs] == EMPTY)).all()
             # filter pawn move
-            pawn_should = (a.to % 8) >= (a.from_ % 8)  # should move forward
+            pawn_should = (to % 8) >= (from_ % 8)  # should move forward
             pawn_should &= (
-                ((a.to // 8 == a.from_ // 8) & (state.board[a.to] == 0)) |   # move up
-                ((a.to // 8 != a.from_ // 8) & (state.board[a.to] < 0))      # capture
+                ((to // 8 == from_ // 8) & (state.board[to] == 0)) |   # move up
+                ((to // 8 != from_ // 8) & (state.board[to] < 0))      # capture
             )
             ok &= (piece != PAWN) | pawn_should
             return jax.lax.select(ok, a._to_label(), -1)

--- a/pgx/_src/games/chess.py
+++ b/pgx/_src/games/chess.py
@@ -417,7 +417,7 @@ def _legal_action_mask(state: GameState) -> Array:
             between_ixs = BETWEEN[from_, to]
             ok &= CAN_MOVE[piece, from_, to] & ((between_ixs < 0) | (state.board[between_ixs] == EMPTY)).all()
             r0, c0, r1, c1 = from_ % 8, from_ // 8, to % 8, to // 8
-            pawn_should = r1 >= r0  # should move forward
+            pawn_should = r1 >= r0  # move forward
             pawn_should &= ((c1 == c0) & (state.board[to] == EMPTY)) | ((c1 != c0) & (state.board[to] < 0))
             ok &= (piece != PAWN) | pawn_should
             return jax.lax.select(ok, Action(from_=from_, to=to)._to_label(), -1)

--- a/pgx/_src/games/chess.py
+++ b/pgx/_src/games/chess.py
@@ -419,9 +419,9 @@ def _legal_action_mask(state: GameState) -> Array:
             between_ixs = BETWEEN[a.from_, a.to]
             ok &= ((between_ixs < 0) | (state.board[between_ixs] == EMPTY)).all()
             # filter pawn move
-            pawn_should = ((a.to % 8) >= (a.from_ % 8))  # should move forward
+            pawn_should = (a.to % 8) >= (a.from_ % 8)  # should move forward
             pawn_should &= (jnp.abs(a.to - a.from_) > 2) | (state.board[a.to] >= 0)  # cannot move up if occupied by opponent
-            pawn_should &= ~((jnp.abs(a.to - a.from_) > 2) & (state.board[a.to] >= 0))  # cannot move diagnally without capturing
+            pawn_should &= (jnp.abs(a.to - a.from_) <= 2) | (state.board[a.to] < 0)  # cannot move diagnally without capturing
             ok &= (piece != PAWN) | pawn_should
             return jax.lax.select(ok, a._to_label(), -1)
 

--- a/pgx/_src/games/chess.py
+++ b/pgx/_src/games/chess.py
@@ -417,8 +417,7 @@ def _legal_action_mask(state: GameState) -> Array:
             between_ixs = BETWEEN[from_, to]
             ok &= CAN_MOVE[piece, from_, to] & ((between_ixs < 0) | (state.board[between_ixs] == EMPTY)).all()
             r0, c0, r1, c1 = from_ % 8, from_ // 8, to % 8, to // 8
-            pawn_should = r1 >= r0  # move forward
-            pawn_should &= ((c1 == c0) & (state.board[to] == EMPTY)) | ((c1 != c0) & (state.board[to] < 0))
+            pawn_should = ((c1 == c0) & (state.board[to] == EMPTY)) | ((c1 != c0) & (state.board[to] < 0))
             ok &= (piece != PAWN) | pawn_should
             return jax.lax.select(ok, Action(from_=from_, to=to)._to_label(), -1)
 
@@ -489,7 +488,6 @@ def _is_attacked(state: GameState, pos):
         between_ixs = BETWEEN[pos, to]
         ok &= ((between_ixs < 0) | (state.board[between_ixs] == EMPTY)).all()
         # For pawn, it should be the forward diagonal direction
-        ok &= ~((piece == PAWN) & ((to % 8) < (pos % 8)))  # should move forward
         ok &= ~((piece == PAWN) & (to // 8 == pos // 8))  # should move diagnally to capture the king
         return ok
 

--- a/pgx/_src/games/chess.py
+++ b/pgx/_src/games/chess.py
@@ -415,15 +415,13 @@ def _legal_action_mask(state: GameState) -> Array:
         def legal_label(to):
             a = Action(from_=from_, to=to)
             ok = (from_ >= 0) & (piece > 0) & (to >= 0) & (state.board[to] <= 0)
-            ok &= CAN_MOVE[piece, from_, to]
             between_ixs = BETWEEN[from_, to]
-            ok &= ((between_ixs < 0) | (state.board[between_ixs] == EMPTY)).all()
+            ok &= CAN_MOVE[piece, from_, to] & ((between_ixs < 0) | (state.board[between_ixs] == EMPTY)).all()
             # filter pawn move
             pawn_should = (to % 8) >= (from_ % 8)  # should move forward
-            pawn_should &= (
-                ((to // 8 == from_ // 8) & (state.board[to] == 0)) |   # move up
-                ((to // 8 != from_ // 8) & (state.board[to] < 0))      # capture
-            )
+            pawn_should &= ((to // 8 == from_ // 8) & (state.board[to] == 0)) | (  # move up
+                (to // 8 != from_ // 8) & (state.board[to] < 0)
+            )  # capture
             ok &= (piece != PAWN) | pawn_should
             return jax.lax.select(ok, a._to_label(), -1)
 

--- a/pgx/_src/games/chess.py
+++ b/pgx/_src/games/chess.py
@@ -408,7 +408,7 @@ def _flip(state: GameState) -> GameState:
 
 def _legal_action_mask(state: GameState) -> Array:
     @jax.vmap
-    def legal_norml_moves(from_):
+    def legal_normal_moves(from_):
         piece = state.board[from_]
 
         @jax.vmap
@@ -457,7 +457,7 @@ def _legal_action_mask(state: GameState) -> Array:
 
     # normal move and en passant
     possible_piece_positions = jnp.nonzero(state.board > 0, size=16, fill_value=-1)[0].astype(jnp.int32)
-    a1 = legal_norml_moves(possible_piece_positions).flatten()
+    a1 = legal_normal_moves(possible_piece_positions).flatten()
     a2 = legal_en_passants()
     actions = jnp.hstack((a1, a2))  # include -1
     actions = jnp.where(is_not_checked(actions), actions, -1)

--- a/pgx/_src/games/chess.py
+++ b/pgx/_src/games/chess.py
@@ -420,8 +420,10 @@ def _legal_action_mask(state: GameState) -> Array:
             ok &= ((between_ixs < 0) | (state.board[between_ixs] == EMPTY)).all()
             # filter pawn move
             pawn_should = (a.to % 8) >= (a.from_ % 8)  # should move forward
-            pawn_should &= (a.to // 8 != a.from_ // 8) | (state.board[a.to] >= 0)  # cannot move up if occupied by opponent
-            pawn_should &= (a.to // 8 == a.from_ // 8) | (state.board[a.to] < 0)  # cannot move diagnally without capturing
+            pawn_should &= (
+                ((a.to // 8 == a.from_ // 8) & (state.board[a.to] == 0)) |   # move up
+                ((a.to // 8 != a.from_ // 8) & (state.board[a.to] < 0))      # capture
+            )
             ok &= (piece != PAWN) | pawn_should
             return jax.lax.select(ok, a._to_label(), -1)
 

--- a/pgx/_src/games/chess.py
+++ b/pgx/_src/games/chess.py
@@ -419,8 +419,8 @@ def _legal_action_mask(state: GameState) -> Array:
             between_ixs = BETWEEN[a.from_, a.to]
             ok &= ((between_ixs < 0) | (state.board[between_ixs] == EMPTY)).all()
             # filter pawn move
-            pawn_should = ~(((a.to % 8) < (a.from_ % 8)))  # should move forward
-            pawn_should &= ~((jnp.abs(a.to - a.from_) <= 2) & (state.board[a.to] < 0))  # cannot move up if occupied by opponent
+            pawn_should = ((a.to % 8) >= (a.from_ % 8))  # should move forward
+            pawn_should &= (jnp.abs(a.to - a.from_) > 2) | (state.board[a.to] >= 0)  # cannot move up if occupied by opponent
             pawn_should &= ~((jnp.abs(a.to - a.from_) > 2) & (state.board[a.to] >= 0))  # cannot move diagnally without capturing
             ok &= (piece != PAWN) | pawn_should
             return jax.lax.select(ok, a._to_label(), -1)

--- a/pgx/_src/games/chess.py
+++ b/pgx/_src/games/chess.py
@@ -416,7 +416,7 @@ def _legal_action_mask(state: GameState) -> Array:
             ok = (from_ >= 0) & (piece > 0) & (to >= 0) & (state.board[to] <= 0)
             between_ixs = BETWEEN[from_, to]
             ok &= CAN_MOVE[piece, from_, to] & ((between_ixs < 0) | (state.board[between_ixs] == EMPTY)).all()
-            r0, c0, r1, c1 = from_ % 8, from_ // 8, to % 8, to // 8
+            c0, c1 = from_ // 8, to // 8
             pawn_should = ((c1 == c0) & (state.board[to] == EMPTY)) | ((c1 != c0) & (state.board[to] < 0))
             ok &= (piece != PAWN) | pawn_should
             return jax.lax.select(ok, Action(from_=from_, to=to)._to_label(), -1)

--- a/pgx/_src/games/chess.py
+++ b/pgx/_src/games/chess.py
@@ -420,8 +420,8 @@ def _legal_action_mask(state: GameState) -> Array:
             ok &= ((between_ixs < 0) | (state.board[between_ixs] == EMPTY)).all()
             # filter pawn move
             pawn_should = (a.to % 8) >= (a.from_ % 8)  # should move forward
-            pawn_should &= (jnp.abs(a.to - a.from_) > 2) | (state.board[a.to] >= 0)  # cannot move up if occupied by opponent
-            pawn_should &= (jnp.abs(a.to - a.from_) <= 2) | (state.board[a.to] < 0)  # cannot move diagnally without capturing
+            pawn_should &= (a.to // 8 != a.from_ // 8) | (state.board[a.to] >= 0)  # cannot move up if occupied by opponent
+            pawn_should &= (a.to // 8 == a.from_ // 8) | (state.board[a.to] < 0)  # cannot move diagnally without capturing
             ok &= (piece != PAWN) | pawn_should
             return jax.lax.select(ok, a._to_label(), -1)
 

--- a/pgx/_src/games/chess.py
+++ b/pgx/_src/games/chess.py
@@ -413,16 +413,14 @@ def _legal_action_mask(state: GameState) -> Array:
 
         @jax.vmap
         def legal_label(to):
-            a = Action(from_=from_, to=to)
             ok = (from_ >= 0) & (piece > 0) & (to >= 0) & (state.board[to] <= 0)
             between_ixs = BETWEEN[from_, to]
             ok &= CAN_MOVE[piece, from_, to] & ((between_ixs < 0) | (state.board[between_ixs] == EMPTY)).all()
-            # filter pawn move
             r0, c0, r1, c1 = from_ % 8, from_ // 8, to % 8, to // 8
             pawn_should = r1 >= r0  # should move forward
             pawn_should &= ((c1 == c0) & (state.board[to] == EMPTY)) | ((c1 != c0) & (state.board[to] < 0))
             ok &= (piece != PAWN) | pawn_should
-            return jax.lax.select(ok, a._to_label(), -1)
+            return jax.lax.select(ok, Action(from_=from_, to=to)._to_label(), -1)
 
         return legal_label(LEGAL_DEST[piece, from_])
 

--- a/pgx/_src/games/chess.py
+++ b/pgx/_src/games/chess.py
@@ -418,10 +418,9 @@ def _legal_action_mask(state: GameState) -> Array:
             between_ixs = BETWEEN[from_, to]
             ok &= CAN_MOVE[piece, from_, to] & ((between_ixs < 0) | (state.board[between_ixs] == EMPTY)).all()
             # filter pawn move
-            pawn_should = (to % 8) >= (from_ % 8)  # should move forward
-            pawn_should &= ((to // 8 == from_ // 8) & (state.board[to] == 0)) | (  # move up
-                (to // 8 != from_ // 8) & (state.board[to] < 0)
-            )  # capture
+            r0, c0, r1, c1 = from_ % 8, from_ // 8, to % 8, to // 8
+            pawn_should = r1 >= r0  # should move forward
+            pawn_should &= ((c1 == c0) & (state.board[to] == EMPTY)) | ((c1 != c0) & (state.board[to] < 0))
             ok &= (piece != PAWN) | pawn_should
             return jax.lax.select(ok, a._to_label(), -1)
 

--- a/pgx/_src/games/chess.py
+++ b/pgx/_src/games/chess.py
@@ -416,8 +416,8 @@ def _legal_action_mask(state: GameState) -> Array:
             ok = (from_ >= 0) & (piece > 0) & (to >= 0) & (state.board[to] <= 0)
             between_ixs = BETWEEN[from_, to]
             ok &= CAN_MOVE[piece, from_, to] & ((between_ixs < 0) | (state.board[between_ixs] == EMPTY)).all()
-            r0, c0, r1, c1 = from_ % 8, from_ // 8, to % 8, to // 8
-            pawn_should = ((c1 == c0) & (state.board[to] == EMPTY)) | ((c1 != c0) & (state.board[to] < 0))
+            in_same_col = (to - from_) % 8 == 0
+            pawn_should = (in_same_col & (state.board[to] == EMPTY)) | (~in_same_col & (state.board[to] < 0))
             ok &= (piece != PAWN) | pawn_should
             return jax.lax.select(ok, Action(from_=from_, to=to)._to_label(), -1)
 

--- a/pgx/_src/games/chess_utils.py
+++ b/pgx/_src/games/chess_utils.py
@@ -72,7 +72,7 @@ CAN_MOVE = np.zeros((7, 64, 64), dtype=np.bool_)
 # Note that the board is not symmetric about the center (different from shogi)
 # You can imagine that the viewpoint is always from the white side.
 # Except PAWN, the moves are symmetric about the center.
-# We define PAWN as a piece that can move up, down, and diagonally, and filter it according to the turn.
+# We define PAWN as a piece that can move left-up, up, right-up.
 
 
 # PAWN
@@ -81,10 +81,10 @@ for from_ in range(64):
     legal_dst = []
     for to in range(64):
         r1, c1 = to % 8, to // 8
-        if np.abs(r1 - r0) == 1 and np.abs(c1 - c0) <= 1:
+        if r1 - r0 == 1 and np.abs(c1 - c0) <= 1:
             legal_dst.append(to)
         # init move
-        if (r0 == 1 or r0 == 6) and (np.abs(c1 - c0) == 0 and np.abs(r1 - r0) == 2):
+        if r0 == 1 and r1 == 3 and np.abs(c1 - c0) == 0:
             legal_dst.append(to)
     assert len(legal_dst) <= 8
     LEGAL_DEST[1, from_, : len(legal_dst)] = legal_dst


### PR DESCRIPTION
#1236 

Also removed unused pawn move destinations from cache #1174

| fn| jaxpr lines | time |
|:---|---:|:---|
| `_legal_action_mask` | 1499 | 465.2ms |
| `_flip` | 91 | 26.2ms |
| `_is_checked` | 156 | 50.2ms |
| `_hash_castling_en_passant` | 37 | 21.3ms |
| `_apply_move` | 258 | 74.5ms |
| `_update_history` | 57 | 29.0ms |