### PR TITLE
[Chess] Reduce `_is_attacked` call

### DIFF
--- a/pgx/_src/games/chess.py
+++ b/pgx/_src/games/chess.py
@@ -351,7 +351,7 @@ def _legal_action_mask(state: GameState) -> Array:
     a1 = jax.vmap(legal_normal_moves)(possible_piece_positions).flatten()
     a2 = legal_en_passants()
     actions = jnp.hstack((a1, a2))  # include -1
-    ixs = jnp.nonzero(actions >= 0, size=16 * 19, fill_value=0)[0]  # 16 * 27 -> 16 * 19
+    ixs = jnp.nonzero(actions >= 0, size=16 * 19, fill_value=0)[0]  # 16 * 27 = 432 -> 16 * 19 = 304
     actions = actions[ixs]
     actions = jnp.where(jax.vmap(is_not_checked)(actions), actions, -1)
     mask = jnp.zeros(64 * 73 + 1, dtype=jnp.bool_)  # +1 for sentinel

--- a/pgx/_src/games/chess.py
+++ b/pgx/_src/games/chess.py
@@ -351,7 +351,7 @@ def _legal_action_mask(state: GameState) -> Array:
     a1 = jax.vmap(legal_normal_moves)(possible_piece_positions).flatten()
     a2 = legal_en_passants()
     actions = jnp.hstack((a1, a2))  # include -1
-    ixs = jnp.nonzero(actions >= 0, size=16 * 19, fill_value=0)[0]  # 16 * 27 = 432 -> 16 * 19 = 304
+    ixs = jnp.nonzero(actions >= 0, size=128, fill_value=0)[0]  # 128: random large number
     actions = actions[ixs]
     actions = jnp.where(jax.vmap(is_not_checked)(actions), actions, -1)
     mask = jnp.zeros(64 * 73 + 1, dtype=jnp.bool_)  # +1 for sentinel

--- a/pgx/_src/games/chess.py
+++ b/pgx/_src/games/chess.py
@@ -351,6 +351,8 @@ def _legal_action_mask(state: GameState) -> Array:
     a1 = jax.vmap(legal_normal_moves)(possible_piece_positions).flatten()
     a2 = legal_en_passants()
     actions = jnp.hstack((a1, a2))  # include -1
+    ixs = jnp.nonzero(actions >= 0, size=16 * 19, fill_value=0)[0]  # 16 * 27 -> 16 * 19
+    actions = actions[ixs]
     actions = jnp.where(jax.vmap(is_not_checked)(actions), actions, -1)
     mask = jnp.zeros(64 * 73 + 1, dtype=jnp.bool_)  # +1 for sentinel
     mask = mask.at[actions].set(True)

--- a/pgx/_src/games/chess.py
+++ b/pgx/_src/games/chess.py
@@ -351,7 +351,7 @@ def _legal_action_mask(state: GameState) -> Array:
     a1 = jax.vmap(legal_normal_moves)(possible_piece_positions).flatten()
     a2 = legal_en_passants()
     actions = jnp.hstack((a1, a2))  # include -1
-    ixs = jnp.nonzero(actions >= 0, size=128, fill_value=0)[0]  # 128: random large number
+    ixs = jnp.nonzero(actions >= 0, size=200, fill_value=0)[0]  # 200: random large number
     actions = actions[ixs]
     actions = jnp.where(jax.vmap(is_not_checked)(actions), actions, -1)
     mask = jnp.zeros(64 * 73 + 1, dtype=jnp.bool_)  # +1 for sentinel

--- a/pgx/_src/games/chess.py
+++ b/pgx/_src/games/chess.py
@@ -83,8 +83,8 @@ ixs = [89, 90, 652, 656, 673, 674, 1257, 1258, 1841, 1842, 2425, 2426, 3009, 301
 INIT_LEGAL_ACTION_MASK[ixs] = True
 
 LEGAL_DEST = -np.ones((7, 64, 27), np.int32)  # LEGAL_DEST[0, :, :] == -1
-LEGAL_DEST_NEAR = -np.ones((64, 16), np.int32)
-LEGAL_DEST_FAR = -np.ones((64, 19), np.int32)
+LEGAL_DEST_NEAR = -np.ones((64, 16), np.int32)  # king and knight moves
+LEGAL_DEST_FAR = -np.ones((64, 19), np.int32)   # queen moves except king moves
 CAN_MOVE = np.zeros((7, 64, 64), dtype=np.bool_)
 for from_ in range(64):
     legal_dest = {p: [] for p in range(7)}

--- a/pgx/_src/games/chess.py
+++ b/pgx/_src/games/chess.py
@@ -351,7 +351,7 @@ def _legal_action_mask(state: GameState) -> Array:
     a1 = jax.vmap(legal_normal_moves)(possible_piece_positions).flatten()
     a2 = legal_en_passants()
     actions = jnp.hstack((a1, a2))  # include -1
-    ixs = jnp.nonzero(actions >= 0, size=200, fill_value=0)[0]  # 200: random large number
+    ixs = jnp.nonzero(actions >= 0, size=128, fill_value=0)[0]  # 128: random large number
     actions = actions[ixs]
     actions = jnp.where(jax.vmap(is_not_checked)(actions), actions, -1)
     mask = jnp.zeros(64 * 73 + 1, dtype=jnp.bool_)  # +1 for sentinel

--- a/pgx/_src/games/chess.py
+++ b/pgx/_src/games/chess.py
@@ -351,8 +351,8 @@ def _legal_action_mask(state: GameState) -> Array:
     a1 = jax.vmap(legal_normal_moves)(possible_piece_positions).flatten()
     a2 = legal_en_passants()
     actions = jnp.hstack((a1, a2))  # include -1
-    ixs = jnp.nonzero(actions >= 0, size=128, fill_value=0)[0]  # 128: random large number
-    actions = actions[ixs]
+    ixs = jnp.nonzero(actions >= 0, size=200, fill_value=0)[0]  # 200 is sufficiently large
+    actions = actions[ixs]  # remove -1
     actions = jnp.where(jax.vmap(is_not_checked)(actions), actions, -1)
     mask = jnp.zeros(64 * 73 + 1, dtype=jnp.bool_)  # +1 for sentinel
     mask = mask.at[actions].set(True)

--- a/pgx/_src/games/chess.py
+++ b/pgx/_src/games/chess.py
@@ -351,7 +351,7 @@ def _legal_action_mask(state: GameState) -> Array:
     a1 = jax.vmap(legal_normal_moves)(possible_piece_positions).flatten()
     a2 = legal_en_passants()
     actions = jnp.hstack((a1, a2))  # include -1
-    # filter out -1. 200 is big enough for normal play. all pawns must promote.
+    # filter out -1. 200 is big enough for normal play.
     ixs = jnp.nonzero(actions >= 0, size=200, fill_value=0)[0]
     actions = actions[ixs]  # size: 19 * 27 -> 200
     # filter ignoring checks and suicides

--- a/pgx/_src/games/chess.py
+++ b/pgx/_src/games/chess.py
@@ -351,8 +351,10 @@ def _legal_action_mask(state: GameState) -> Array:
     a1 = jax.vmap(legal_normal_moves)(possible_piece_positions).flatten()
     a2 = legal_en_passants()
     actions = jnp.hstack((a1, a2))  # include -1
-    ixs = jnp.nonzero(actions >= 0, size=200, fill_value=0)[0]  # 200 is sufficiently large
-    actions = actions[ixs]  # remove -1
+    # filter out -1. 200 is big enough for normal play. all pawns must promote.
+    ixs = jnp.nonzero(actions >= 0, size=200, fill_value=0)[0]
+    actions = actions[ixs]  # size: 19 * 27 -> 200
+    # filter ignoring checks and suicides
     actions = jnp.where(jax.vmap(is_not_checked)(actions), actions, -1)
     mask = jnp.zeros(64 * 73 + 1, dtype=jnp.bool_)  # +1 for sentinel
     mask = mask.at[actions].set(True)


### PR DESCRIPTION
As `is_attacked` call is bottleneck, this PR intends to reduce it.

In normal play, the number of legal action is < 200. See these extreme examples without black pieces:

| | 9 Queens | 8 Queens |
|:---:|:---:|:---:|
| # legal actions | `206` | `196` |
| board | <img width="356" alt="image" src="https://github.com/user-attachments/assets/ec768c6e-63b9-46e2-8b07-f323f9ecf805"> | <img width="339" alt="image" src="https://github.com/user-attachments/assets/1b7ba5a1-9b89-4b11-9e9e-a6f421c49fe6"> |

These examples are found by black box optimization. There might be larger example but I believe 200 is quite enough.