### PR TITLE
[Hex] Modify visualizer.py to handle TypeError when displaying the initial state of hex.

### DIFF
--- a/pgx/_src/visualizer.py
+++ b/pgx/_src/visualizer.py
@@ -391,7 +391,7 @@ class Visualizer:
             from pgx._src.dwg.hex import _make_hex_dwg, four_dig
 
             self.config["GRID_SIZE"] = 30
-            size = int(_state._size) # type:ignore
+            size = int(jnp.array(_state._size).ravel()[0])
             self.config["BOARD_WIDTH"] = four_dig(size * 1.5) # type:ignore
             self.config["BOARD_HEIGHT"] = four_dig(size * jnp.sqrt(3) / 2) # type:ignore
             self._make_dwg_group = _make_hex_dwg  # type:ignore

--- a/pgx/_src/visualizer.py
+++ b/pgx/_src/visualizer.py
@@ -391,20 +391,9 @@ class Visualizer:
             from pgx._src.dwg.hex import _make_hex_dwg, four_dig
 
             self.config["GRID_SIZE"] = 30
-            try:
-                self.config["BOARD_WIDTH"] = four_dig(
-                    _state._size[0] * 1.5  # type:ignore
-                )
-                self.config["BOARD_HEIGHT"] = four_dig(
-                    _state._size[0] * jnp.sqrt(3) / 2  # type:ignore
-                )
-            except IndexError:
-                self.config["BOARD_WIDTH"] = four_dig(
-                    _state._size * 1.5  # type:ignore
-                )
-                self.config["BOARD_HEIGHT"] = four_dig(
-                    _state._size * jnp.sqrt(3) / 2  # type:ignore
-                )
+            size = int(_state._size) # type:ignore
+            self.config["BOARD_WIDTH"] = four_dig(size * 1.5) # type:ignore
+            self.config["BOARD_HEIGHT"] = four_dig(size * jnp.sqrt(3) / 2) # type:ignore
             self._make_dwg_group = _make_hex_dwg  # type:ignore
             if (self.config["COLOR_THEME"] is None and self.config["COLOR_THEME"] == "dark") or self.config[
                 "COLOR_THEME"


### PR DESCRIPTION
# Issue
We cannot visualize the initial state of `hex`.
It raises `TypeError: 'int' object is not subscriptable`.

# Reason 
This is caused by the following code in line 396 of visualizer.py.
```
self.config["BOARD_WIDTH"] = four_dig(
    _state._size[0] * 1.5  # type:ignore
)
```
The current implementation above tries to read `_state._size`, which is int object.
Also, python raises `TypeError`, therefore it would not be caught by the exception handler `except IndexError:`.

# Proposal 
I propose to convert `_state._size` into `int` via one dimensional `jnp.array`.
I think this is stabler because both `int` and `jaxlib.xla_extension.ArrayImpl` with one element can be converted to `int`.

# Reproduction of the error

If we run the following code, we get `TypeError: 'int' object is not subscriptable`.

```
import jax
import pgx

print(pgx.__version__)   # -> 2.4.0
env = pgx.make("hex")
state = env.init(jax.random.key(42))
print(type(state._size)) # -> <class 'int'>
print(state._size)       # -> 11
display(state)
```

Or, this is the screenshot if you prefer.
<img width="898" alt="screenshot 2024-10-23 16 29 28" src="https://github.com/user-attachments/assets/d2e70394-ce66-47cf-9f32-37fb4b42ea42">


