### PR TITLE
[API] Deprecate `player_id` in observe

### DIFF
--- a/pgx/core.py
+++ b/pgx/core.py
@@ -232,7 +232,7 @@ class Env(abc.ABC):
         if player_id is None:
             player_id = state.current_player
         else:
-            warnings.warn("[Pgx] `player_id` is deprecated. This argument will be removed in the future.", DeprecationWarning)
+            warnings.warn("[Pgx] `player_id` in `observe` is deprecated. This argument will be removed in the future.", DeprecationWarning)
         obs = self._observe(state, player_id)
         return jax.lax.stop_gradient(obs)
 


### PR DESCRIPTION
#1154

While, this feature makes the implementation complicated, this feature is rarely used because we are interested in the observation of current player to act.
