### PR TITLE
[Shogi] Randomly initialize the `current_player` variable.

### DIFF
--- a/pgx/shogi.py
+++ b/pgx/shogi.py
@@ -50,9 +50,14 @@ class Shogi(core.Env):
         self._game = Game()
 
     def _init(self, key: PRNGKey) -> State:
-        state = State()
-        player_order = jnp.array([[0, 1], [1, 0]])[jax.random.bernoulli(key).astype(jnp.int32)]
-        return state.replace(_player_order=player_order)  # type: ignore
+        x = GameState()
+        _player_order = jnp.array([[0, 1], [1, 0]])[jax.random.bernoulli(key).astype(jnp.int32)]
+        state = State(  # type: ignore
+            current_player=_player_order[x.color],
+            _player_order=_player_order,
+            _x=x,
+        )
+        return state
 
     def _step(self, state: core.State, action: Array, key) -> State:
         del key


### PR DESCRIPTION
Thank you for developing your nice library. I am really enjoying using it.

## Issue
In Shogi environment, `current_player` is not randomly initialized.
This can cause issues when the users use the information of `current_player` in their code.

The following code can reproduce this issue.

```python
import pgx
import jax

env = pgx.make("chess")
chess_states = jax.vmap(env.init)(jax.random.split(jax.random.key(0), 16))
print(chess_states.current_player) # -> [0 0 1 1 1 0 1 1 1 0 1 0 0 0 1 0]

env = pgx.make("shogi")
shogi_states = jax.vmap(env.init)(jax.random.split(jax.random.key(0), 16))
print(shogi_states.current_player) # -> [0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]
```

## Reason
In the `_init` function of [pgx/pgx/shogi.py](https://github.com/sotetsuk/pgx/blob/main/pgx/shogi.py#L52-L55), the variable `player_order` is randomly initialized, but it is not reflected to the variable `current_player`. 

Therefore, `current_player` stays to be `jnp.int32(0)`, as initialized in [class definition](https://github.com/sotetsuk/pgx/blob/main/pgx/shogi.py#L31).

## Proposal
I propose to initialize the `current_player` variable in the `_init` function. 

Specifically, I propose to copy and paste the `_init` function in [chess.py](https://github.com/sotetsuk/pgx/blob/main/pgx/chess.py) into [shogi.py](https://github.com/sotetsuk/pgx/blob/main/pgx/shogi.py).