### PR TITLE
[Shogi] Update the explanation of the action space in the document.

### DIFF
--- a/docs/shogi.md
+++ b/docs/shogi.md
@@ -103,7 +103,7 @@ The design of action also follows that of dlshogi.
 There are `2187 = 81 x 27` distinct actions.
 The action can be decomposed into 
 
-- `direction` from which the piece moves and
+- `direction` to which the piece moves and
 - `destination` to which the piece moves
 
 by `direction, destination = action // 81, action % 81`.


### PR DESCRIPTION
素晴らしいライブラリをご開発いただき、ありがとうございます。いつも楽しんで使わせていただいております。

## 提案

以下の通り、shogi ドキュメントの action の direction の説明を、「`direction` **from** which the piece moves and」から「`direction` **to** which the piece moves and」に変更することを提案します。

### 変更前
```
There are `2187 = 81 x 27` distinct actions.
The action can be decomposed into 

- `direction` from which the piece moves and
- `destination` to which the piece moves
```

### 変更後
```
There are `2187 = 81 x 27` distinct actions.
The action can be decomposed into 

- `direction` to which the piece moves and
- `destination` to which the piece moves
```

## 理由
例えば７六歩は行動番号では59であり、これは

- `direction`: 0 (Up)
- `destination`: 53 (７六の地点)

に対応します。この場合、歩は上に**向かって**進む（上**から**来るわけではない）ので、「to which」の方が直感的かと思い、以上の変更を提案いたします。
