### PR TITLE
[Chess] from_fen: don't inherit phantom startpos history

### DIFF
--- a/pgx/experimental/chess.py
+++ b/pgx/experimental/chess.py
@@ -66,6 +66,9 @@ def from_fen(fen: str):
         halfmove_count=jnp.int32(halfmove_cnt),
         fullmove_count=jnp.int32(fullmove_cnt),
     )
+    # default GameState carries the startpos in hash_history[0]/board_history[0]; clear both
+    # so the restored position does not inherit a phantom repetition/observation entry
+    x = x._replace(hash_history=jnp.zeros_like(x.hash_history), board_history=jnp.zeros_like(x.board_history))
     legal_action_mask = jax.jit(_legal_action_mask)(x)
     x = x._replace(legal_action_mask=legal_action_mask)
     x = _update_history(x)


### PR DESCRIPTION
## Summary

`GameState()` defaults carry the start position in `hash_history[0]` and `board_history[0]`. `pgx.experimental.chess.from_fen` builds on those defaults and then rolls them via `_update_history`, so every restored position claims the standard start position as its previous position:

- `hash_history[1]` contains the startpos Zobrist hash → a phantom repetition entry. Restoring the start position itself via `from_fen` immediately reports one repetition; any game that later transposes back to the startpos-hash counts one repetition too many.
- `board_history[1]` contains the startpos board → the oldest observation history plane shows a position that was never played.

## Fix

Clear both histories before calling `_update_history`, so the restored position starts with a clean history (matching the semantics of a position restored from FEN, which has no known past).

```py
x = x._replace(hash_history=jnp.zeros_like(x.hash_history), board_history=jnp.zeros_like(x.board_history))
```