### PR TITLE
[Chess] Fix stale INIT_ZOBRIST_HASH: derive it from the Zobrist tables at import time

### DIFF
--- a/pgx/_src/games/chess.py
+++ b/pgx/_src/games/chess.py
@@ -134,7 +134,20 @@ ZOBRIST_BOARD = jax.random.randint(keys[0], shape=(64, 13, 2), minval=0, maxval=
 ZOBRIST_SIDE = jax.random.randint(keys[1], shape=(2,), minval=0, maxval=2**31 - 1, dtype=jnp.uint32)
 ZOBRIST_CASTLING = jax.random.randint(keys[2], shape=(4, 2), minval=0, maxval=2**31 - 1, dtype=jnp.uint32)
 ZOBRIST_EN_PASSANT = jax.random.randint(keys[3], shape=(65, 2), minval=0, maxval=2**31 - 1, dtype=jnp.uint32)
-INIT_ZOBRIST_HASH = jnp.uint32([1455170221, 1478960862])
+
+
+def _init_zobrist_hash() -> Array:
+    # Derived from the tables above instead of hardcoded: the tables come from jax.random,
+    # whose outputs are not stable across JAX versions — a stale constant silently breaks
+    # repetition counting for the initial position.
+    hash_ = ZOBRIST_SIDE  # color == 0
+    hash_ ^= lax.reduce(ZOBRIST_BOARD[jnp.arange(64), INIT_BOARD + 6], 0, lax.bitwise_xor, (0,))
+    hash_ ^= lax.reduce(ZOBRIST_CASTLING, 0, lax.bitwise_xor, (0,))  # all castling rights
+    hash_ ^= ZOBRIST_EN_PASSANT[-1]  # en_passant == -1
+    return hash_
+
+
+INIT_ZOBRIST_HASH = _init_zobrist_hash()
 
 
 class GameState(NamedTuple):


### PR DESCRIPTION
## Bug

The Zobrist tables in `pgx/_src/games/chess.py` are generated at import time from `jax.random`, whose outputs are **not stable across JAX versions** (e.g. the `threefry_partitionable` default change). The hardcoded constant

```py
INIT_ZOBRIST_HASH = jnp.uint32([1455170221, 1478960862])
```

no longer matches `_zobrist_hash(GameState())` under current JAX (0.10.1 gives `[1875025768, 182641400]`). Since `GameState()` seeds `hash_history[0]` with the stale constant while every later entry is recomputed, the initial position's history entry never matches:

- **Repetitions involving the start position are counted one short.** Repro: the knight shuffle `g1f3 g8f6 f3g1 f6g8 g1f3 g8f6 f3g1 f6g8` is a threefold repetition at ply 8, but pgx terminates only at ply 9 (when the position after 1.Nf3 repeats a third time instead).
- The repetition observation planes (`rep0`/`rep1`) are wrong for the startpos history entry.

```py
import jax.numpy as jnp
import pgx._src.games.chess as C
print(C.INIT_ZOBRIST_HASH)            # [1455170221 1478960862]
print(C._zobrist_hash(C.GameState())) # [1875025768  182641400]  <- mismatch
```

## Fix

Compute the constant from the actual tables at import time (same XOR-reduce idiom as `_zobrist_hash`), so it can never go stale again, under any JAX version. On JAX versions where the old constant happened to match, this is a no-op.

Note: `gardner_chess.py` and `animal_shogi.py` hardcode similar init-hash constants and likely have the same issue; this PR fixes chess only.